### PR TITLE
A11y contrast fix/work around

### DIFF
--- a/components/Page.js
+++ b/components/Page.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Meta from '../components/meta';
+import HighContrast from '../components/highcontrast';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import stylesheet from '../styles/style.styl';
@@ -9,6 +10,8 @@ export default class Page extends React.Component {
     return (
       <div className="page">
         <a href="#main" className="skip-link">Skip to content</a>
+        {/* <a href="#" id="highcontrast">High Contrast Mode</a> */}
+        <HighContrast />
         <Header />
         <style dangerouslySetInnerHTML={{ __html: stylesheet.replace(/\n/g, '') }} />
         {this.props.children}

--- a/components/highcontrast.js
+++ b/components/highcontrast.js
@@ -12,7 +12,6 @@ export default class highContrast extends React.Component{
     }));
     let html = document.querySelector('html');
     html.classList.toggle('highcontrast');
-    console.log(html.classList);
   }
 
   render() {

--- a/components/highcontrast.js
+++ b/components/highcontrast.js
@@ -1,0 +1,25 @@
+export default class highContrast extends React.Component{
+  constructor(props) {
+    super(props);
+    this.state = { isActive: false};
+    this.highContrastMode = this.highContrastMode.bind(this);
+  }
+
+  highContrastMode(e) {
+    e.preventDefault();
+    this.setState(state => ({
+      isActive: !state.isActive
+    }));
+    let html = document.querySelector('html');
+    html.classList.toggle('highcontrast');
+    console.log(html.classList);
+  }
+
+  render() {
+    return (
+      <a href="#" id="highcontrast" onClick={this.highContrastMode}>
+        {this.state.isActive ? 'High Contrast Mode Off': 'High Contrast Mode'}
+      </a>
+    );
+  }
+}

--- a/styles/_high_contrast.styl
+++ b/styles/_high_contrast.styl
@@ -1,0 +1,29 @@
+.highcontrast
+  filter: grayscale(100%)
+  body
+    background: #000
+    .subscribe a
+      color: #fff
+      background: #000
+      border: 1px solid #fff
+      border-radius: 3px
+      margin: -1px
+    .show__displayNumber
+      color: #333
+#highcontrast
+  border 1px solid yellow
+  border-radius 3px
+  padding 5px 10px
+  position fixed
+  top 15px
+  right 15px
+  font-size 12px
+  &:hover
+    border 1px dotted
+  @media (max-width: 767px)
+    position relative
+    margin 10px 15px
+    text-align center
+    display block
+    right: auto
+    top 0

--- a/styles/style.styl
+++ b/styles/style.styl
@@ -3,6 +3,7 @@
 @import '_type.styl'
 @import '_layout.styl'
 @import '_skiplink.styl'
+@import '_high_contrast.styl'
 @import '_header.styl'
 @import '_person.styl'
 @import '_player.styl'


### PR DESCRIPTION
Here is something I made at work to try to help my company with color contrast issues

Added a button that toggles a class of high contrast that fixes some of the issues related to color contrast found in AXE. The body changes from the background image you currently have to black and then changes the subscribe link buttons to be black and white again to help with contrast issues. I positioned it in the upper right hand corner right now to not take away from everything else and not to make it look like a call to action button