### PR TITLE
Update styling to fix accessibility issue. Links only distinguishable…

### DIFF
--- a/styles/_person.styl
+++ b/styles/_person.styl
@@ -19,6 +19,8 @@
     font-size 2rem
     em
       font-size 1rem
+  a
+    text-decoration: underline
 
 .avatar
   border-radius 50%


### PR DESCRIPTION
… by colour

The links in Scott and Wes' bios have an accessibility problem: they're only distinguishable by colour (WCAG 1.4.1). I've added an underline to them, similar to the links in the show notes!

Thanks, big fan of the podcast!

Ross