### PR TITLE
Scrollable Views

### DIFF
--- a/components/ShowNotes.js
+++ b/components/ShowNotes.js
@@ -1,31 +1,40 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-const ShowNotes = ({ show, setCurrentPlaying }) => (
-  <div className="showNotes">
-    <p className="show__date">{show.displayDate}</p>
-    <h2>{show.title}</h2>
-    <button
-      className="button"
-      onClick={() => setCurrentPlaying(show.displayNumber)}
-      type="button"
-    >
-      <span className="icon">🎵</span> Play Episode {show.displayNumber}
-    </button>
-    <a className="button" download href={show.url}>
-      <span className="icon">👇</span> Download Show
-    </a>
-    <a
-      className="button"
-      href={`https://github.com/wesbos/Syntax/edit/master/${show.notesFile}`}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      <span className="icon">✏️</span> Edit Show Notes
-    </a>
-    <div dangerouslySetInnerHTML={{ __html: show.html }} />
-  </div>
-);
+const ShowNotes = ({ show, setCurrentPlaying }) => {
+  const componentEl = useRef(null);
+
+  useEffect(() => {
+    document.getElementById('main').scrollIntoView();
+    componentEl.current.scrollTop = 0;
+  });
+
+  return (
+    <div className="showNotes" ref={componentEl}>
+      <p className="show__date">{show.displayDate}</p>
+      <h2>{show.title}</h2>
+      <button
+        className="button"
+        onClick={() => setCurrentPlaying(show.displayNumber)}
+        type="button"
+      >
+        <span className="icon">🎵</span> Play Episode {show.displayNumber}
+      </button>
+      <a className="button" download href={show.url}>
+        <span className="icon">👇</span> Download Show
+      </a>
+      <a
+        className="button"
+        href={`https://github.com/wesbos/Syntax/edit/master/${show.notesFile}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <span className="icon">✏️</span> Edit Show Notes
+      </a>
+      <div dangerouslySetInnerHTML={{ __html: show.html }} />
+    </div>
+  );
+};
 
 ShowNotes.propTypes = {
   show: PropTypes.object.isRequired,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5171,25 +5171,36 @@
       }
     },
     "react": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.7.0.tgz",
-      "integrity": "sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==",
+      "version": "16.8.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.0-alpha.1.tgz",
+      "integrity": "sha512-vLwwnhM2dXrCsiQmcSxF2UdZVV5xsiXjK5Yetmy8dVqngJhQ3aw3YJhZN/YmyonxwdimH40wVqFQfsl4gSu2RA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "scheduler": "^0.13.0-alpha.1"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.13.0-alpha.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.0-alpha.1.tgz",
+          "integrity": "sha512-W0sH0848sVuPKg+I18vTYQyzVtA4X1lrVgSeXK6KnOPUltFdJcY5nkbTkjGUeS/E0x+eBsNYfSdhJtGjT95njw==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-dom": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.7.0.tgz",
-      "integrity": "sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==",
+      "version": "16.8.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.0-alpha.1.tgz",
+      "integrity": "sha512-tZCUM8BpnwUHJmLnUWP9c3vVZxnCqYotj7s4tx7umojG6BKv745KIBtuPTzt0EI0q50GMLEpmT/CPQ8iA61TwQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "scheduler": "^0.13.0-alpha.1"
       }
     },
     "react-icons": {
@@ -5773,9 +5784,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
-      "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
+      "version": "0.13.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.0-alpha.1.tgz",
+      "integrity": "sha512-W0sH0848sVuPKg+I18vTYQyzVtA4X1lrVgSeXK6KnOPUltFdJcY5nkbTkjGUeS/E0x+eBsNYfSdhJtGjT95njw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "postcss-loader": "2.1.5",
     "prop-types": "^15.6.2",
     "raw-loader": "^0.5.1",
-    "react": "^16.4.1",
-    "react-dom": "^16.4.1",
+    "react": "^16.8.0-alpha.1",
+    "react-dom": "^16.8.0-alpha.1",
     "react-icons": "^3.0.5",
     "speakingurl": "^14.0.1"
   },

--- a/pages/index.js
+++ b/pages/index.js
@@ -44,7 +44,6 @@ export default withRouter(
     setCurrentPlaying = (currentPlaying) => {
       console.log('Setting current playing');
       this.setState({ currentPlaying });
-      this.mainEl.scrollIntoView();
     };
 
     render() {

--- a/pages/index.js
+++ b/pages/index.js
@@ -44,6 +44,7 @@ export default withRouter(
     setCurrentPlaying = (currentPlaying) => {
       console.log('Setting current playing');
       this.setState({ currentPlaying });
+      this.mainEl.scrollIntoView();
     };
 
     render() {

--- a/styles/_show.styl
+++ b/styles/_show.styl
@@ -77,6 +77,8 @@
   overflow scroll
   @media (max-width: 650px)
     width 100%
+    max-height initial
+    overflow auto
   .button
     border-bottom 0
   ul

--- a/styles/_show.styl
+++ b/styles/_show.styl
@@ -61,8 +61,8 @@
 
 .showList
   width 38%
-  display flex
-  flex-direction column
+  max-height: 100vh;
+  overflow scroll
   @media (max-width: 650px)
     height 300px
     width 100%
@@ -73,6 +73,8 @@
   padding 2rem
   width 62%
   font-size 1.5rem
+  max-height 100vh
+  overflow scroll
   @media (max-width: 650px)
     width 100%
   .button


### PR DESCRIPTION
Inspired by my tweet to Syntax.fm (https://twitter.com/syntaxfm/status/1080239058926948353) ...someone over there thought it was a good idea so I figured I'd take a crack at it! 

This PR allows both the show notes and the show list divs to be scrolled independently of each other. Now you can keep the currently selected show in view as you scroll through its show notes. As a bonus, it also scrolls to the top of the show notes container whenever a show is selected. No more blank show notes sections when picking a show towards the bottom of the list!

One big thing - I bumped React to 16.8.0.alpha (the one with hooks) as part of this PR. This was to make the bit of functionality that scrolls to the top of the show notes container a bit easier to do without converting the entire showNotes container into a class component. If preference is not to leap into the future of React just yet, happy to provide an alternate way of accomplishing this.