### PR TITLE
Apply momentum scroll to show list

### DIFF
--- a/styles/_show.styl
+++ b/styles/_show.styl
@@ -68,6 +68,7 @@
     width 100%
     overflow-x auto
     overflow-y scroll
+    -webkit-overflow-scrolling: touch
 
 .showNotes
   position sticky


### PR DESCRIPTION
Hey Wes,

On iOS the show list scrolls without momentum scroll unless you add this CSS property:
`-webkit-overflow-scrolling: touch`

It makes for a much smoother experience with this enabled. Try it for yourself.