### PR TITLE
feat: Convert show notes timestamps to audio player time links

### DIFF
--- a/components/Player.js
+++ b/components/Player.js
@@ -7,6 +7,7 @@ import VolumeBars from './VolumeBars';
 export default class Player extends React.Component {
   static propTypes = {
     show: PropTypes.object.isRequired,
+    clickedTimestamp: PropTypes.number,
     onPlayPause: PropTypes.func,
   };
 
@@ -49,7 +50,7 @@ export default class Player extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) { //eslint-disable-line
-    const { show } = this.props;
+    const { show, clickedTimestamp } = this.props;
     const { currentTime, currentVolume, playbackRate } = this.state;
     if (show.number !== prevProps.show.number) {
       const lp = localStorage.getItem(`lastPlayed${show.number}`);
@@ -83,6 +84,9 @@ export default class Player extends React.Component {
         `lastPlaybackSetting`,
         JSON.stringify({ lastPlaybackRate: playbackRate })
       );
+    }
+    if (clickedTimestamp !== prevProps.clickedTimestamp) {
+      this.audio.currentTime = clickedTimestamp;
     }
   }
 

--- a/pages/show/[number]/[slug].js
+++ b/pages/show/[number]/[slug].js
@@ -62,6 +62,7 @@ export default withRouter(
       this.state = {
         currentShow,
         currentPlaying: currentShow,
+        clickedTimestamp: undefined,
         isPlaying: false,
       };
     }
@@ -89,7 +90,12 @@ export default withRouter(
         return <ErrorPage statusCode={404} />
       }
 
-      const { currentShow, currentPlaying, isPlaying } = this.state;
+      const {
+        currentShow,
+        currentPlaying,
+        isPlaying,
+        clickedTimestamp,
+      } = this.state;
       const show = shows.find(showItem => showItem.displayNumber === currentShow)
       const current = shows.find(showItem => showItem.displayNumber === currentPlaying)
       return (
@@ -97,7 +103,11 @@ export default withRouter(
           <Meta show={show} />
           <div className="wrapper">
             <main className="show-wrap" id="main" tabIndex="-1">
-              <Player show={current} onPlayPause={a => this.setIsPlaying(!a.paused)}/>
+              <Player
+                show={current}
+                clickedTimestamp={clickedTimestamp}
+                onPlayPause={(a) => this.setIsPlaying(!a.paused)}
+              />
               <ShowList
                 shows={shows}
                 currentShow={currentShow}
@@ -108,6 +118,12 @@ export default withRouter(
               <ShowNotes
                 show={show}
                 setCurrentPlaying={this.setCurrentPlaying}
+                onClickTimestamp={(timestamp) => {
+                  this.setState({
+                    currentPlaying: show.displayNumber,
+                    clickedTimestamp: timestamp,
+                  });
+                }}
               />
             </main>
           </div>

--- a/styles/_show.styl
+++ b/styles/_show.styl
@@ -105,7 +105,11 @@
     padding 1rem
   h1,h2
     font-size 2.5rem
-  a
+  a, .link
+    outline: none
+    background: none
+    border: none
+    padding: 0
     color lighten(black, 20%)
     border-bottom 1px solid yellow
     text-decoration none


### PR DESCRIPTION
### Context
Bumped a couple of times in a situation where having the timestamps clickable would be really useful, so I decided to have a go at it.

### What is done
All show notes word matching the format `1:00` or `01:00` are replaced by buttons.
A timestamp button, when clicked, sends its timestamp in seconds to the `Player` component, which will update the current time on the audio player.

### What it looks like
![timestamps](https://user-images.githubusercontent.com/5920450/87208317-484fbb80-c2dc-11ea-8390-3c03b39293f9.png)
