### PR TITLE
Make "Play Episode" play episode on latest episode

### DIFF
--- a/components/Player.js
+++ b/components/Player.js
@@ -45,7 +45,10 @@ export default class Player extends React.Component {
 
   componentDidUpdate(prevProps, prevState) { //eslint-disable-line
     const { show } = this.props;
-    const { currentTime, currentVolume, playbackRate } = this.state;
+    const { currentTime, currentVolume, playbackRate, playing } = this.state;
+    if (!playing && this.props.isPlaying) {
+      this.audio.play();
+    }
     if (show.number !== prevProps.show.number) {
       const lp = localStorage.getItem(`lastPlayed${show.number}`);
       if (lp) {
@@ -278,4 +281,5 @@ export default class Player extends React.Component {
 Player.propTypes = {
   show: PropTypes.object.isRequired,
   onPlayPause: PropTypes.func,
+  isPlaying: PropTypes.bool,
 };

--- a/pages/show/[number]/[slug].js
+++ b/pages/show/[number]/[slug].js
@@ -81,15 +81,28 @@ export default function IndexPage({ showNumber, shows }) {
       <Meta show={show} />
       <div className="wrapper">
         <main className="show-wrap" id="main" tabIndex="-1">
-          <Player show={current} onPlayPause={a => setIsPlaying(!a.paused)} />
+          <Player
+            show={current}
+            onPlayPause={a => setIsPlaying(!a.paused)}
+            isPlaying={isPlaying}
+          />
           <ShowList
             shows={shows}
             currentShow={currentShow}
             currentPlaying={currentPlaying}
-            setCurrentPlaying={setCurrentPlaying}
+            setCurrentPlaying={n => {
+              setCurrentPlaying(n);
+              setIsPlaying(true);
+            }}
             isPlaying={isPlaying}
           />
-          <ShowNotes show={show} setCurrentPlaying={setCurrentPlaying} />
+          <ShowNotes
+            show={show}
+            setCurrentPlaying={n => {
+              setCurrentPlaying(n);
+              setIsPlaying(true);
+            }}
+          />
         </main>
       </div>
     </Page>


### PR DESCRIPTION
This fixes a confusing interaction I had on your site:

1. Load up Syntax.fm
2. Click  "Play Episode 290" (the latest episode)
3. Nothing happens

This will make the button start playing the episode even if it's the latest episode and already loaded in the player. It also makes it resume playing when you pause but then hit the "Play Episode" button. 