### PR TITLE
Focus the show notes when you click a show #564

### DIFF
--- a/components/Show.js
+++ b/components/Show.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import slug from 'speakingurl';
 import { FaPlay } from 'react-icons/fa';
-import Link from 'next/link';
+import ShowLink from './ShowLink';
 import Bars from './bars';
 
 export default class Show extends React.Component {
@@ -21,24 +20,11 @@ export default class Show extends React.Component {
         } ${currentShow === show.displayNumber ? 'show--active' : ''}
       `}
       >
-        <Link
-          shallow
-          scroll={false}
-          href="/show/[number]/[slug]"
-          as={`/show/${show.displayNumber}/${slug(show.title)}`}
-        >
-          <a className="show__link">
-            <div className="show__container">
-              <p className="show__displayNumber">
-                Episode {show.displayNumber}
-              </p>
-              <span className="show__seperator"> | </span>
-              <p className="show__modifiedDate">{show.displayDate}</p>
-            </div>
-            <h3 className="show__title">{show.title}</h3>
-          </a>
-        </Link>
-
+        <ShowLink
+          displayNumber={show.displayNumber}
+          title={show.title}
+          displayDate={show.displayDate}
+        />
         <div className="show__playcontrols">
           {currentPlaying === show.displayNumber ? (
             <Bars isPlaying={isPlaying} />

--- a/components/ShowLink.js
+++ b/components/ShowLink.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import Link from 'next/link';
+import slug from 'speakingurl';
+import PropTypes from 'prop-types';
+
+const ShowLink = ({ displayNumber, displayDate, title }) => {
+  const handleAnchorClick = () => {
+    document.querySelector('.showNotes').focus();
+  };
+
+  return (
+    <Link
+      shallow
+      scroll={false}
+      href="/show/[number]/[slug]"
+      as={`/show/${displayNumber}/${slug(title)}`}
+    >
+      <button className="show__link" onClick={handleAnchorClick} type="button">
+        <div className="show__container">
+          <p className="show__displayNumber">Episode {displayNumber}</p>
+          <span className="show__seperator"> | </span>
+          <p className="show__modifiedDate">{displayDate}</p>
+        </div>
+        <h3 className="show__title">{title}</h3>
+      </button>
+    </Link>
+  );
+};
+
+ShowLink.propTypes = {
+  displayNumber: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  displayDate: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+};
+
+export default ShowLink;

--- a/components/ShowNotes.js
+++ b/components/ShowNotes.js
@@ -8,7 +8,11 @@ const ShowNotes = ({ show, setCurrentPlaying }) => {
   });
 
   return (
-    <div className="showNotes">
+    <div
+      className="showNotes"
+      tabIndex="-1"
+      aria-label={`Show Notes for ${show.title}`}
+    >
       <p className="show__date">{show.displayDate}</p>
       <h2>{show.title}</h2>
       <button

--- a/styles/_show.styl
+++ b/styles/_show.styl
@@ -7,7 +7,7 @@
   display flex
   @media (max-width: 650px)
     flex 1 0 auto
-  a
+  a, button
     flex 1 1 auto
     padding 10px
   &__playcontrols
@@ -75,8 +75,19 @@
     width 100%
     overflow-x auto
     overflow-y scroll
+  .show__link
+    &:focus
+      outline 1px solid yellow
+    appearance none
+    background transparent
+    border none
+    line-height 1.5
+    text-align left
 
 .showNotes
+  &:focus
+    outline 1px solid yellow
+    outline-offset -1px
   position sticky
   top 102px
   height calc(100vh - 102px)


### PR DESCRIPTION
**Changes**

1. Wrapped the ShowLink Link into a new ShowLink component
2. Added tabIndex of -1 to the showNotes container div to make it programatically focusable.
3. Changes the anchor tab to a button so we get those native keyboard behaviours by default. Some styling needed to be 
    added to make it look as before.
4. On ShowLink button click, we programatically set focus to the showNotes container.

![564](https://user-images.githubusercontent.com/12486130/99959566-28003500-2d83-11eb-8364-522a2a085cd4.gif)


