### PR TITLE
feat: Add new method to get paginated shows with offset and limit

### DIFF
--- a/lib/getShows.js
+++ b/lib/getShows.js
@@ -61,6 +61,11 @@ async function getShows(filter) {
     : showsForGetShows.filter(show => show.date < now);
 }
 
+async function getShowsPaginated(offset,limit) {
+  const showsForGetShows = await loadShows();
+  return showsForGetShows.slice(offset,offset+limit);
+}
+
 async function getShow(number) {
   const showsForGetShow = await loadShows();
   const show = showsForGetShow.find(
@@ -98,6 +103,7 @@ async function getAllShowSickPicks() {
 
 module.exports = {
   getShows,
+  getShowsPaginated,
   getShow,
   getAllShowSickPicks,
 };

--- a/pages/api/shows/paginated.js
+++ b/pages/api/shows/paginated.js
@@ -1,0 +1,22 @@
+import Cors from 'cors';
+import { getShowsPaginated } from '../../../lib/getShows';
+import initMiddleware from '../../../lib/initMiddleware';
+
+const cors = initMiddleware(
+  Cors({
+    methods: ['GET', 'OPTIONS'],
+  })
+);
+
+export default async function showsPaginated(req, res) {
+  await cors(req, res);
+
+  const shows = await getShowsPaginated(req.query.offset,req.query.limit);
+  if (shows) {
+    res.json(shows);
+    return;
+  }
+  res
+    .status(404)
+    .json({ message: `Sorry, we could not find shows between ${req.query.offset} and ${req.query.limit}` });
+}


### PR DESCRIPTION
### Description

As request in the issue #651 it would be nice to have the results list paginated in order to implement a lazy loading list that loads content on scroll.

### Solution

I've added a new method in the API endpoint to get the shows paginated. Now if you call the API endpoint `api/shows/paginated` like this:

```
https://syntax.fm/api/shows/paginated?offset=0&limit=20
```

you'll get the first 20 episodes, and so on depending on the offset and limit values. Operation is practically the same as SQL queries with the OFFSET and LIMIT keywords.

