### PR TITLE
Add ID to each item on sick picks page

### DIFF
--- a/pages/sickpicks.js
+++ b/pages/sickpicks.js
@@ -26,6 +26,7 @@ export default class SickPicksPage extends React.Component {
           {sickPicks.map((sickPick) => (
             <div
               key={sickPick.id}
+              id={`episode-number-${sickPick.id}`}
               dangerouslySetInnerHTML={{ __html: sickPick.html }} //eslint-disable-line
             />
           ))}


### PR DESCRIPTION
- the Sick Picks page is pretty long, with a several hundred sets of picks
- directing someone to a specific set of picks on this page is not really feasible
  - sick picks on episode pages appear to have an ID, but linking to the picks page is more direct for sharing
- this allows linking directly to a named anchor

For example, `http://localhost:6969/sickpicks#episode-number-382` would take you directly to the picks on the page for that episode.