### PR TITLE
Shownotes external links are now blue

### DIFF
--- a/styles/_show.styl
+++ b/styles/_show.styl
@@ -109,6 +109,12 @@
     color lighten(black, 20%)
     border-bottom 1px solid yellow
     text-decoration none
+  a[href]:not(.button,:where([href^="#"],[href^="/"]:not([href^="//"]),[href*="//syntax.fm"],[href*="wesbos" i],[href*="leveluptutorials" i],[href*="stolinski" i],[href*="twitter.com/syntaxfm" i]))
+      color blue
+      position relative
+      &:hover
+        color lighten(blue, 20%)
+        border-bottom-color lighten(blue, 20%)  
   code
     background: #f4f4f4;
     border: 1px solid #ddd;

--- a/styles/_variables.styl
+++ b/styles/_variables.styl
@@ -10,6 +10,6 @@ lightgrey = #f9f9f9
 lightgray = lightgrey
 green = #03fff3
 newgrey =  #645555
-
+blue = #3171d8
 
 grad = linear-gradient(30deg, #d2ff52 0%, green 100%);


### PR DESCRIPTION
This PR implements the suggestion I made in issue #809

- Adding the variable `blue` with the value `#0969da`
- Applying `blue` to links in the shownotes, unless they:
  - Are anchor-links (`#`)
  - Link to the root (`/`)
  - Link to `//syntax.fm`
  - Contains any of the following (case insensitive) strings
    - `wesbos`
    - `leveluptutorials`
    - `stolinski`
    - `twitter.com/syntaxfm`
- On hover, the color of the link, as well as it's yellow `border-bottom-color` is changed to `lighten(blue, 20%)` 

This highlights the links that might be new to us (we are already following you on Twitter), using a color that is associated with links (`blue`).

It only affects the links in the shownotes using the `.showNotes` selector.

<table>
    <thead>
        <tr>
            <th>Before</th>
            <th>After</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img width="464" alt="Screenshot 2022-10-05 at 13 35 17" src="https://user-images.githubusercontent.com/1999142/194052760-37d596bd-c918-44ac-9884-8a4712f773b7.png">
            </td>
            <td>
                <img width="451" alt="Screenshot 2022-10-05 at 13 35 06" src="https://user-images.githubusercontent.com/1999142/194052775-a4ee501f-a7bb-4428-9fec-c79b690ed718.png">
            </td>
        </tr>
    </tbody>
</table>