### PR TITLE
Update 616 - adam CSS.md

### DIFF
--- a/shows/616 - adam CSS.md
+++ b/shows/616 - adam CSS.md
@@ -39,6 +39,7 @@ In this supper club episode of Syntax, Wes and Scott talk with Adam Argyle about
 * **[33:06](#t=33:06)** Cascade layers
 * **[34:40](#t=34:40)** CSS Nesting
 * **[38:03](#t=38:03)** Animate discrete properties
+* [Feature: Transitions on specified discrete properties](https://chromestatus.com/feature/5071230636392448)
 * **[39:42](#t=39:42)** Linear function
 * [Linear easing generator](https://linear-easing-generator.netlify.app/)
 * **[41:33](#t=41:33)** Media query range syntax


### PR DESCRIPTION
Add link to transitions on discrete properties

This change adds a link to the Chrome status issue on the feature change to support transitions on specified discrete properties.

I'm not entirely sure this is the correct link, but I couldn't find anything else related on the matter.