### PR TITLE
Use eslint-plugin-svelte / fix peer dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"@typescript-eslint/parser": "^6.4.0",
 		"eslint": "^8.47.0",
 		"eslint-config-prettier": "^9.0.0",
-		"eslint-plugin-svelte3": "^4.0.0",
+		"eslint-plugin-svelte": "^2.32.4",
 		"postcss": "^8.4.27",
 		"postcss-custom-media": "^10.0.0",
 		"postcss-import": "^15.1.0",


### PR DESCRIPTION
npm install was failing because of peer dependency issues (eslint-plugin-svelte3 wanted svelte3 whereas we're using svelte4). I solved by just switching to eslint-plugin-svelte, which seems to be recommended and works.

Before: 

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: syntax-2@0.0.1
npm ERR! Found: svelte@4.2.0
npm ERR! node_modules/svelte
npm ERR!   dev svelte@"^4.2.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer svelte@"^3.2.0" from eslint-plugin-svelte3@4.0.0
npm ERR! node_modules/eslint-plugin-svelte3
npm ERR!   dev eslint-plugin-svelte3@"^4.0.0" from the root project
```
