### PR TITLE
Fix show number redirects

### DIFF
--- a/src/routes/(site)/[show_number]/+page.server.ts
+++ b/src/routes/(site)/[show_number]/+page.server.ts
@@ -6,8 +6,8 @@ export const load: PageServerLoad = async function ({ params, locals, setHeaders
 		'cache-control': 'max-age=240'
 	});
 
-	const { number } = params;
-	const show = await locals.prisma.show.findFirst({ where: { number: parseInt(number) } });
-	if (show) throw redirect(302, `/shows/${number}/${show.slug}`);
-	throw redirect(302, `/shows}`);
+	const { show_number } = params;
+	const show = await locals.prisma.show.findFirst({ where: { number: parseInt(show_number) } });
+	if (show) throw redirect(302, `/shows/${show_number}/${show.slug}`);
+	throw redirect(302, `/shows`);
 };


### PR DESCRIPTION
#### Purpose

This PR fixes #1174 by changing the route parameter `[number=show_number]` to just `[show_number]`.

Also fixes a small typo which was causing an error to be thrown when redirecting for invalid `show_number` values.