### PR TITLE
removes regex lookbehind, not compatible with safari < 16.3

### DIFF
--- a/src/params/ThemeMaker.svelte
+++ b/src/params/ThemeMaker.svelte
@@ -11,7 +11,7 @@
 
 	// TODO refactor to utility function
 	function getThemeName(path: string) {
-		let match_temp = path.match(themeName)?.[0];
+		let match_temp = path.split('/').pop()?.split('.')[0];
 		return match_temp;
 	}
 


### PR DESCRIPTION
I think this will fix  https://github.com/syntaxfm/website/issues/1251