### PR TITLE
remove port from OG image URL

### DIFF
--- a/src/routes/(site)/+layout.server.ts
+++ b/src/routes/(site)/+layout.server.ts
@@ -1,6 +1,6 @@
 import { PUBLIC_URL } from '$env/static/public';
 
-const social_banner = `https://${PUBLIC_URL}:5173/syntax-banner.png`;
+const social_banner = `https://${PUBLIC_URL}/syntax-banner.png`;
 
 export const load = async ({ locals }) => {
 	return {


### PR DESCRIPTION
the og image has a port in the URL, which means it's not showing up. 