### PR TITLE
Add explicit accessible names to show actions

### DIFF
--- a/src/lib/ListenLinks.svelte
+++ b/src/lib/ListenLinks.svelte
@@ -8,6 +8,7 @@
 	class="icon"
 	target="_blank"
 	title="Listen on Spotify"
+	aria-label="Spotify"
 	href="https://open.spotify.com/search/syntax.fm {encodeURI(show.title)}/episodes"
 >
 	<Icon name="spotify" />
@@ -15,6 +16,7 @@
 <a
 	class="icon"
 	title="Listen on Apple Podcasts"
+	aria-label="Apple Podcasts"
 	target="_blank"
 	href="https://podcasts.apple.com/ca/podcast/syntax-tasty-web-development-treats/id1253186678"
 >

--- a/src/routes/(site)/show/[show_number]/[slug]/[[tab]]/+page.svelte
+++ b/src/routes/(site)/show/[show_number]/[slug]/[[tab]]/+page.svelte
@@ -86,11 +86,12 @@
 			<ListenLinks {show} />
 		</div>
 		<div>
-			<a class="icon" title="Download Episode" download href={show.url}>
+			<a class="icon" title="Download Episode" aria-label="Download" download href={show.url}>
 				<Icon name="download" />
 			</a>
 			<a
 				title="Edit Show Notes"
+				aria-label="Edit Show Notes"
 				class="icon"
 				href={'https://github.com/syntaxfm/website/tree/main' + show.md_file}
 			>

--- a/src/routes/(site)/show/[show_number]/[slug]/[[tab]]/+page.svelte
+++ b/src/routes/(site)/show/[show_number]/[slug]/[[tab]]/+page.svelte
@@ -79,7 +79,7 @@
 	<div class="show-actions zone" style="--bg: var(--black); --fg: var(--white);">
 		<div class="show-actions-flex">
 			<button on:click={() => player.play_show(show)} data-testid="play-show">
-				<Icon name="play{$player.current_show?.number === show.number ? 'ing' : ''}" />
+				<Icon title="" name="play{$player.current_show?.number === show.number ? 'ing' : ''}" />
 				Play{$player.current_show?.number === show.number ? 'ing' : ''} Episode {show.number}
 			</button>
 			<span>or</span>


### PR DESCRIPTION
The links in the show actions are have titles which get used as fallback for the accessible name, but it's better to be explicit (and more terse, since context informs the text as well)