### PR TITLE
fix some tiny CSS things

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -9,7 +9,7 @@
 	}
 
 	*,
-	*::before-,
+	*::before,
 	*::after {
 		box-sizing: inherit;
 	}
@@ -77,7 +77,7 @@
 		font-style: italic;
 	}
 
-	/* FYI haven'te installed this font yet, just trying it for fun with my installed version */
+	/* FYI haven't installed this font yet, just trying it for fun with my installed version */
 	h1,
 	h2,
 	h3,
@@ -302,9 +302,8 @@ in a later release. */
 
 /* Popover */
 
-/* All External Links */
-a[href^='http']:not(.social-icon, .button, .icon, .naked):after,
-a[href^='https']:not(.social-icon, .button, .icon, .naked):after {
+/* All External Links (links starting with http(s)) */
+a[href^='http']:not(.social-icon, .button, .icon, .naked):after {
 	content: '↗';
 	margin-left: 4px;
 	font-size: 12px;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -303,7 +303,7 @@ in a later release. */
 /* Popover */
 
 /* All External Links (links starting with http(s)) */
-a[href^='http']:not(.social-icon, .button, .icon, .naked):after {
+a[href^='http']:not(.social-icon, .button, .icon, .naked)::after {
 	content: '↗';
 	margin-left: 4px;
 	font-size: 12px;


### PR DESCRIPTION
- Fixes a typo: `*:before-`
- Fixes a comment typo
- Removes an unneeded selector, because `[href^=http]` [matches both](https://codepen.io/bartveneman/pen/gOqMeWx?editors=1100) http and https links 
<img width="1192" alt="Three links, two in red because they match the preceding attribute selector" src="https://github.com/syntaxfm/website/assets/1536852/9dda6c6b-99b4-4fa8-9efe-c16649c600b8">
