### PR TITLE
Don't initialize Redis if no credentials

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -15,10 +15,13 @@ import { UPSPLASH_TOKEN, UPSPLASH_URL } from '$env/static/private';
 
 export const cache_status = UPSPLASH_URL || UPSPLASH_TOKEN ? 'ONLINE' : 'OFFLINE';
 
-export const redis = new Redis({
-	url: UPSPLASH_URL,
-	token: UPSPLASH_TOKEN
-});
+export const redis =
+	cache_status == 'ONLINE'
+		? new Redis({
+				url: UPSPLASH_URL,
+				token: UPSPLASH_TOKEN
+		  })
+		: null;
 
 console.log(`🤓 Cache Status... ${cache_status}`);
 


### PR DESCRIPTION
Fixes #1393

I notice in other parts of the code, we check if `redis` is non-null so I think this is ok?