### PR TITLE
Fix @​layer initialisation

### DIFF
--- a/src/routes/(site)/style.css
+++ b/src/routes/(site)/style.css
@@ -1,4 +1,4 @@
-/* 
+,/* 
 ░██████╗██╗░░░██╗███╗░░██╗
 ██╔════╝╚██╗░██╔╝████╗░██║
 ╚█████╗░░╚████╔╝░██╔██╗██║
@@ -15,7 +15,7 @@
 
 /* The main css entry. Primarily used to import stuff */
 
-@layer reset base utilities layout theme;
+@layer reset, base, utilities, layout, theme;
 
 /* Import all css themes */
 @import '../../styles/base.css';


### PR DESCRIPTION
Comma-separates the layer names to guarantuee the correct order. Without the commas it's seen as a single layer name.

[Project Wallace](https://www.projectwallace.com/analyze-css?url=https%3A%2F%2Fsyntax.fm%2F&prettify=1) found this issue when inspecting the unique layer names and checking out the layer composition:

<img width="576" alt="Screenshot 2023-11-29 at 17 38 57" src="https://github.com/syntaxfm/website/assets/1536852/74b17985-9608-4763-a2a4-24f766de1906">


<img width="1433" alt="Screenshot 2023-11-29 at 17 39 19" src="https://github.com/syntaxfm/website/assets/1536852/f11b6ca7-2e31-4977-8601-b0c310bcfab7">

--- 

And thanks again for the shoutout!! ❤️ 