### PR TITLE
#1195: Stop the player and reset player state when close is called

### DIFF
--- a/src/state/player.ts
+++ b/src/state/player.ts
@@ -36,14 +36,16 @@ function loadMediaSession(show: Show) {
 	});
 }
 
+interface PlayerState {
+	status: 'HIDDEN' | 'ACTIVE' | 'EXPANDED';
+	current_show: null | Show;
+	playing: boolean;
+	currentTime: number;
+	audio?: HTMLAudioElement;
+}
+
 const new_player_state = () => {
-	const { subscribe, update, set } = writable<{
-		status: 'HIDDEN' | 'ACTIVE' | 'EXPANDED';
-		current_show: null | Show;
-		playing: boolean;
-		audio?: HTMLAudioElement;
-		currentTime: number;
-	}>({
+	const { subscribe, update, set } = writable<PlayerState>({
 		status: 'HIDDEN',
 		current_show: null,
 		playing: false,
@@ -109,6 +111,16 @@ const new_player_state = () => {
 	function close() {
 		update((state) => {
 			state.status = 'HIDDEN';
+			state.current_show = null;
+			state.playing = false;
+			state.currentTime = 0;
+
+			if (state.audio) {
+				state.audio.pause();
+				state.audio.src = '';
+				state.audio.crossOrigin = null;
+				state.audio.currentTime = 0;
+			}
 			return state;
 		});
 	}


### PR DESCRIPTION
## Overview
Only stop the player and reset the player state when close is called.

This would interfere a tiny bit with https://github.com/syntaxfm/website/pull/1203
The fix for that should only be in the state object, so whichever is merged first, we can fix the other.

Related to https://github.com/syntaxfm/website/issues/1195

## Some other ideas
It could be good to save settings like timestamp for previously played podcasts and playback speed selection

Added a video but had to reduce the quality because of GH's limits

https://github.com/syntaxfm/website/assets/17347266/87079815-835b-4245-9ea0-a91951a8f396

