### PR TITLE
Handle a 404/infinite redirect

### DIFF
--- a/src/routes/(site)/shows/+page.server.ts
+++ b/src/routes/(site)/shows/+page.server.ts
@@ -35,7 +35,12 @@ export const load: PageServerLoad = async function ({ locals, url, setHeaders })
 		console.log(`No shows on this page, redirecting to page 1`);
 		const params = new URLSearchParams(url.searchParams);
 		params.delete('page');
-		throw redirect(302, `/shows?${params.toString()}`);
+		const params_string = params.toString();
+		if (params_string.length <= 0) {
+			console.log(`No params for this page redirect. Abort to the homepage!`);
+			throw redirect(302, `/`);
+		}
+		throw redirect(302, `/shows?${params_string}`);
 	}
 
 	return {


### PR DESCRIPTION
This probably would not happen in production, and when there is an update to seeding the dev database, it might not occur in dev either.

But this is a slight change to check if the params string is empty, which happened to me when there were no shows in the DB.

This caused an infinite redirect loop.

No worries if we want to close this because it may never happen in real scenarios.