### PR TITLE
Use caret ranges for engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 	},
 	"type": "module",
 	"engines": {
-		"node": ">=18.0.0 <19.0.0 || >=20.0.0 <21.0.0",
+		"node": "^18 || ^20",
 		"pnpm": ">=8"
 	},
 	"dependencies": {


### PR DESCRIPTION
npm is using [`node-semver`](https://github.com/npm/node-semver) to check the version of the engines. For example https://github.com/npm/cli/blob/86ac76caa4a8bd5d1acb1777befdbc4d9ebc8a1a/docs/bin/build.js#L3C1-L3C1.

They are also using [caret ranges](https://github.com/npm/node-semver#caret-ranges-123-025-004) for engines. See https://github.com/npm/cli/blob/latest/package.json#L266.

