### PR TITLE
Add newsletter to nav links

### DIFF
--- a/src/routes/(site)/Header.svelte
+++ b/src/routes/(site)/Header.svelte
@@ -18,6 +18,7 @@
 
 		<nav class="desktop_nav content">
 			<a class={$page.url.pathname.startsWith('/shows') ? 'active' : ''} href="/shows">Shows</a>
+			<a class={$page.url.pathname.startsWith('/snackpack') ? 'active' : ''} href="/snackpack">Newsletter</a>
 			<a class={$page.url.pathname.startsWith('/about') ? 'active' : ''} href="/about">About</a>
 			<a class={$page.url.pathname.startsWith('/potluck') ? 'active' : ''} href="/potluck"
 				>Potluck Qs</a

--- a/src/routes/(site)/Header.svelte
+++ b/src/routes/(site)/Header.svelte
@@ -37,6 +37,10 @@
 		background-color: var(--bg);
 		color: var(--fg);
 		padding: 0 0.5rem;
+		@media(--below_large) {
+			padding: 0;
+		}
+
 		&.transparent {
 			background: none;
 		}
@@ -74,6 +78,10 @@
 		display: flex;
 		padding: 10px 0;
 		gap: 10px;
+		@media (--below_large) {
+			gap: 5px;
+		}
+
 		justify-content: flex-end;
 		align-items: center;
 		.transparent & {
@@ -85,6 +93,9 @@
 			text-decoration: none;
 			background: rgba(255, 255, 255, 0.0786987545689);
 			padding: 10px 20px;
+			@media (--below_large) {
+				padding: 8px 16px;
+			}
 			border: 0;
 			border-radius: 20px;
 			align-items: center;

--- a/src/routes/(site)/MobileNav.svelte
+++ b/src/routes/(site)/MobileNav.svelte
@@ -20,6 +20,7 @@
 			<button class="button-reset close-button" on:click={toggle}>×</button>
 			<nav>
 				<a on:click={toggle} href="/shows">Shows</a>
+				<a on:click={toggle} href="/snackpack">Newsletter</a>
 				<a on:click={toggle} href="/about">About</a>
 				<a on:click={toggle} href="/potluck">Potluck Qs</a>
 				<a on:click={toggle} target="_blank" href="https://sentry.shop">Swag</a>


### PR DESCRIPTION
From index:

![image](https://github.com/syntaxfm/website/assets/2153/9b37e789-cf9d-487c-ade4-c44b693068f0)

I made some style tweaks so that the nav fits when ~700-900px (tighten the pill padding by a few pixels, reduce the gap between pills, etc):

![image](https://github.com/syntaxfm/website/assets/2153/7308809e-b255-440a-8ceb-ea018f6960f3)

When visiting `/snackpack`:

![image](https://github.com/syntaxfm/website/assets/2153/00696903-af37-4d01-80a2-c339d37501a3)
