### PR TITLE
Improve image loading on guests page

### DIFF
--- a/src/routes/(site)/guests/+page.svelte
+++ b/src/routes/(site)/guests/+page.svelte
@@ -62,11 +62,11 @@
 	</div>
 
 	<div class="guests">
-		{#each guests as guest}
+		{#each guests as guest, index}
 			<div class="guest">
 				<div>
 					<a href="/guest/{guest.name_slug}">
-						<img src="https://github.com/{guest.github || 'null'}.png" alt={guest.name} />
+						<img src="https://github.com/{guest.github || 'null'}.png" alt={guest.name} width="460" height="460" loading={index < 10 ? 'eager' : 'lazy'} />
 					</a>
 				</div>
 				<div class="info">


### PR DESCRIPTION
Add some lazy loading and explicit image dimensions in case CSS fails. Should save ~7MB when loading the page. I picked 10 images for eager loading because on desktop 2 rows of 5 images are initially visible. Mobile shows 2 or 4 images initially.

<img width="719" alt="Firefox devtools showing 102 image requests with a total of 8.65MB" src="https://github.com/bartveneman/syntax-website/assets/1536852/cfebc9ce-b5fd-4f5a-ba30-2540467d8ea8">
