### PR TITLE
Accessibility Suggestion

### DIFF
--- a/src/lib/search/SearchBox.svelte
+++ b/src/lib/search/SearchBox.svelte
@@ -292,7 +292,7 @@
 		border: none;
 		padding: 10px;
 		font-size: var(--font-size-md);
-		outline: none;
+		outline-color: transparent;
 		background-color: transparent;
 		color: var(--fg);
 		font-family: var(--body-font-family);


### PR DESCRIPTION
Small accessibility defect in CSS when using "outline: none" was fixed. Made simple changes following best practices to prevent users with higher contrasts from experiencing bugs when using the tab key to select buttons, inputs, etc. Reference: https://www.youtube.com/shorts/4B_4WLpbyp8