### PR TITLE
Fix missing show number in recent searches

### DIFF
--- a/src/lib/search/SearchResultList.svelte
+++ b/src/lib/search/SearchResultList.svelte
@@ -63,7 +63,7 @@
 				data-has-node={is_tree(result) ? true : undefined}
 			>
 				<strong class="wrap">
-					<mark>#{result?.node?.number}</mark>
+					<mark>#{is_tree(result) ? result.node.number : result.number}</mark>
 					{@html excerpt(result.breadcrumbs[result.breadcrumbs.length - 1], query, false)}
 				</strong>
 


### PR DESCRIPTION
In the search modal's recent searches, every show number is shown as `undefined`. 

![image](https://github.com/syntaxfm/website/assets/39754176/1e4d63b3-661b-4cc4-ba04-b2641b15bffb)

This is because in recent searches, the variable `result` has the type `Block & Show`, but in the normal search results, `result` has the type `Tree`.

After the fix:
![image](https://github.com/syntaxfm/website/assets/39754176/e430fc17-1d55-4a2c-9313-d75fd6fd5b3d)