### PR TITLE
Fix #1472. Update search input's right padding.

### DIFF
--- a/src/lib/search/SearchBox.svelte
+++ b/src/lib/search/SearchBox.svelte
@@ -290,7 +290,7 @@
 	.search-input {
 		width: 100%;
 		border: none;
-		padding: 10px;
+		padding: 10px 50px 10px 10px;
 		font-size: var(--font-size-md);
 		outline: none;
 		background-color: transparent;


### PR DESCRIPTION
Fixes the issue #1472 by adding right padding to a search input so that text is not overlapped by a close button.

<img width="593" alt="image" src="https://github.com/syntaxfm/website/assets/78966165/8e486e80-7893-4f6c-a03b-6e1f69323a4c">
