### PR TITLE
Change show 713 sick picks timecode

### DIFF
--- a/shows/713 - supper Eric.md
+++ b/shows/713 - supper Eric.md
@@ -40,7 +40,7 @@ In this supper club episode of Syntax, Wes and Scott talk with Eric Meyer about 
 * [Thunderbird — Free Your Inbox. — Thunderbird](https://www.thunderbird.net/en-US/)
 * [Arc from The Browser Company](https://arc.net/)
 * [Mozilla Foundation - Homepage](https://foundation.mozilla.org/en/)
-* **[01:58](#t=01:58)** Sick Picks
+* **[01:01:58](#t=01:01:58)** Sick Picks
 
 ### Sick Picks
 


### PR DESCRIPTION
Fixes #1484 (Hopefully)

I am not sure whether or not this wrong timecode exists anywhere else, or is it only present in a .md file. If you could check it, that would be great as the `pnpm db:seed` seeds database only to 705th show, so there is no way (that I'm aware of) to check the 713th episode