### PR TITLE
Tweak OG card design to accomodate x/twitter title overlay

### DIFF
--- a/src/lib/FacePile.svelte
+++ b/src/lib/FacePile.svelte
@@ -18,12 +18,12 @@
 		--local-size: var(--face-size, 50px);
 		display: grid;
 		grid-auto-flow: column;
-		grid-auto-columns: calc(var(--local-size) / 1.5);
+		grid-auto-columns: calc(var(--local-size) / 1.2);
 		gap: 0;
 		transition: all 0.2s;
 	}
 	.pile:hover {
-		gap: calc(var(--local-size) / 2);
+		gap: calc(var(--local-size) / 4);
 	}
 	img {
 		width: var(--local-size);

--- a/src/lib/ShowOg.svelte
+++ b/src/lib/ShowOg.svelte
@@ -57,9 +57,9 @@
 	}
 </script>
 
-<article class="grit" style="--title-length: {show.title.length}">
+<article style="--title-length: {show.title.length}">
 	{#if show.number}
-		<span class="show-number">{show.number}</span>
+		<span class="grit show-number">{show.number}</span>
 	{/if}
 
 	<div class="details">
@@ -91,7 +91,7 @@
 					}))
 				]}
 			/>
-			<div class="logos">
+			<div class="grit logos">
 				<svg height="100px" viewBox="0 0 1371 1212" fill="none" xmlns="http://www.w3.org/2000/svg">
 					<title>Syntax</title>
 					<path

--- a/src/lib/ShowOg.svelte
+++ b/src/lib/ShowOg.svelte
@@ -81,7 +81,7 @@
 
 		<div class="brand-footer">
 			<FacePile
-				size="80px"
+				size="120px"
 				faces={[
 					{ name: 'Wes Bos', github: 'wesbos' },
 					{ name: 'Scott Tolinski', github: 'stolinski' },
@@ -148,8 +148,10 @@
 		width: 100%;
 		font-style: italic;
 		transform: rotate(-1deg);
-		/* align-self: end; */
 		text-align: center;
+
+		/* black text outline in case white h1 text goes over yellow show number */
+		text-shadow: 2px 0 0 black, 0 2px 0 black, -2px 0 0 black, 0 -2px 0 black;
 	}
 
 	.date {
@@ -186,6 +188,7 @@
 		gap: 5rem;
 		justify-content: center;
 		align-items: center;
+		margin-bottom: 4rem;
 	}
 	.logos {
 		bottom: 10px;


### PR DESCRIPTION
Fixes #1479 

This does a couple things:
* Adds margin-bottom to the face pile + syntax logo to push that content up (note this also moves the h1 title text up a bit)
* Adds a `text-shadow` outline to the `h1` title text in case it overlays the yellow show number
* Makes the face pile avatars bigger (`120px`)
* Increases the gap between the face pile avatars (this also affects other pages, e.g. regular web show cards)
* Removes the "grit" texture mask from the datetime and avatars

At 1200x630:

![image](https://github.com/syntaxfm/website/assets/2153/5c3900ce-5852-4cd0-a205-68b69611a42f)
