### PR TITLE
Make show title + description more accessible by adding contrast

### DIFF
--- a/src/lib/ShowCard.svelte
+++ b/src/lib/ShowCard.svelte
@@ -73,11 +73,11 @@
 			</svelte:element>
 
 			{#if show.aiShowNote?.description}
-				<p id={aria_key} class="description text-sm">{show.aiShowNote?.description}</p>
+				<p id={aria_key} class="description text-sm"><span>{show.aiShowNote?.description}</span></p>
 			{:else}
 				{@const description = show.show_notes?.match(/(.*?)(?=## )/s)?.[0]}
 				<p id={aria_key} class="description text-sm">
-					{description}
+					<span>{description}</span>
 				</p>
 			{/if}
 
@@ -188,6 +188,12 @@
 		font-weight: 600;
 		font-size: var(--font-size-lg);
 		line-height: 1.2;
+		text-shadow: 1px 0 0 var(--bg), 0 1px 0 var(--bg), -1px 0 0 var(--bg), 0 -1px 0 var(--bg);
+	}
+
+	.description span {
+		/* helps a11y when light text overlaps show number */
+		background-color: color-mix(in lch, var(--bg), transparent 50%);
 	}
 
 	.date {

--- a/src/routes/(site)/show/[show_number]/[slug]/+layout.svelte
+++ b/src/routes/(site)/show/[show_number]/[slug]/+layout.svelte
@@ -67,7 +67,7 @@
 		<span class="spa-ran-wrap">{show.title}</span>
 	</h1>
 	{#if show.aiShowNote?.description}
-		<p class="description">{show.aiShowNote?.description}</p>
+		<p class="description"><span>{show.aiShowNote?.description}</span></p>
 	{/if}
 </header>
 
@@ -144,6 +144,12 @@
 			view-transition-name: var(--transition-name);
 			margin-top: 0;
 			font-size: var(--font-size-xxl);
+			text-shadow: 1px 0 0 var(--bg), 0 1px 0 var(--bg), -1px 0 0 var(--bg), 0 -1px 0 var(--bg);
+		}
+
+		.description span {
+			/* helps a11y when light text overlaps show number */
+			background-color: color-mix(in lch, var(--bg), transparent 50%);
 		}
 
 		.show-actions-wrap {


### PR DESCRIPTION
Fixes #1432 

This treatment uses CSS variables + `color-mix` and I've verified it with light and dark themes.

Before:

![image](https://github.com/syntaxfm/website/assets/2153/2cad836d-d9f1-4688-95e1-d3d736b047ea)

After:

![image](https://github.com/syntaxfm/website/assets/2153/d3b8aa71-6f22-4934-8dd1-ae16d9235707)
