### PR TITLE
Improve card layout/readability on small viewports (mobile)

### DIFF
--- a/src/lib/ShowCard.svelte
+++ b/src/lib/ShowCard.svelte
@@ -135,11 +135,13 @@
 			display: flex;
 			gap: 10px;
 			padding: 5px;
+			height: 100%;
 		}
 
 		.details {
 			display: grid;
 			flex-grow: 1;
+			grid-template-rows: 1rem auto 1fr 1rem auto;
 			gap: 1rem;
 			& > * {
 				margin: 0;

--- a/src/lib/ShowCard.svelte
+++ b/src/lib/ShowCard.svelte
@@ -91,7 +91,8 @@
 				</Badges>
 			{/if}
 
-			<FacePile
+			<div class="bottom-row">
+				<FacePile
 				faces={[
 					{ name: 'Wes Bos', github: 'wesbos' },
 					{ name: 'Scott Tolinski', github: 'stolinski' },
@@ -112,6 +113,8 @@
 					>
 				</div>
 			{/if}
+			</div>
+
 		</div>
 	</a>
 </article>
@@ -129,7 +132,6 @@
 		align-items: start;
 		& a {
 			color: var(--fg);
-			display: block;
 			display: flex;
 			gap: 10px;
 			padding: 5px;
@@ -137,6 +139,7 @@
 
 		.details {
 			display: grid;
+			flex-grow: 1;
 			gap: 1rem;
 			& > * {
 				margin: 0;
@@ -190,6 +193,20 @@
 			}
 		}
 
+		.bottom-row {
+			align-self: end;
+
+			/* lay out horizontally */
+			display: grid;
+			grid-template-columns: 1fr 1fr;
+			gap: 1rem;
+
+			.buttons {
+				text-align: right;
+				align-self: center;
+			}
+		}
+
 	}
 
 	.h3 {
@@ -210,6 +227,8 @@
 		@media (prefers-color-scheme: dark) {
 			background: var(--bg);
 		}
+		/* adds contrast when light text overlaps show number */
+		text-shadow: 2px 1px 0px var(--bg);
 	}
 
 	.play-button {

--- a/src/lib/ShowCard.svelte
+++ b/src/lib/ShowCard.svelte
@@ -134,14 +134,13 @@
 			color: var(--fg);
 			display: flex;
 			gap: 10px;
-			padding: 5px;
 			height: 100%;
 		}
 
 		.details {
 			display: grid;
 			flex-grow: 1;
-			grid-template-rows: 1rem auto 1fr 1rem auto;
+			grid-template-rows: auto auto 1fr auto auto;
 			gap: 1rem;
 			& > * {
 				margin: 0;
@@ -189,6 +188,11 @@
 		@media (--below_med) {
 			padding: 10px;
 
+			.details {
+				/* since we're hiding the description row at these dimensions (which was 100% height), 
+				   need a new row to become 100% height -- the show title */
+				grid-template-rows: auto 1fr auto auto;
+			}
 			.description {
 				display: none;
 				mask-image: none;

--- a/src/lib/ShowCard.svelte
+++ b/src/lib/ShowCard.svelte
@@ -165,21 +165,31 @@
 			border: solid var(--border-size) var(--black-8);
 		}
 
+		
 		&.list {
 			border: solid 1px var(--subtle);
 			margin-bottom: 20px;
 			padding: 20px 0;
 			margin-inline: auto;
-			@media (--below_med) {
-				.description {
-					display: none;
-				}
-				h2 {
-					mask-image: none;
-					font-style: normal;
-				}
+		}
+
+		.description {
+			span {
+				/* helps a11y when light text overlaps show number */
+				background-color: color-mix(in lch, var(--bg), transparent 50%);				
 			}
 		}
+
+		/* readability improvements for mobile viewports */
+		@media (--below_med) {
+			padding: 10px;
+
+			.description {
+				display: none;
+				mask-image: none;
+			}
+		}
+
 	}
 
 	.h3 {
@@ -189,11 +199,6 @@
 		font-size: var(--font-size-lg);
 		line-height: 1.2;
 		text-shadow: 1px 0 0 var(--bg), 0 1px 0 var(--bg), -1px 0 0 var(--bg), 0 -1px 0 var(--bg);
-	}
-
-	.description span {
-		/* helps a11y when light text overlaps show number */
-		background-color: color-mix(in lch, var(--bg), transparent 50%);
 	}
 
 	.date {
@@ -233,6 +238,10 @@
 		color: var(--primary);
 		line-height: 1;
 		z-index: -1;
+
+		@media (--below_med) {
+			--max-font-size: 8rem;
+		}
 	}
 
 	@container show-card (width > 600px) {


### PR DESCRIPTION
Refs #1359 

The goal of this PR is to let users see more shows when scrolling through the default route or `/shows` on mobile.

Changes in this PR:
- Put faces + play button on same row
- Hide card descriptions at small viewport width
- Reduce show number font size at small viewport width
- Add some shadow to the date text to help contrast when overlapping w/ date (happens at small viewport width)

Before (note only 2 cards visible):

<img width="612" alt="image" src="https://github.com/syntaxfm/website/assets/2153/04734b20-4ec3-46da-aaa1-8e2cf10cd4a8">

After:

<img width="612" alt="image" src="https://github.com/syntaxfm/website/assets/2153/c2674c4b-d744-4e87-89dd-e4201b4e6883">

Note some design changes in this PR affect other non-mobile layouts, e.g. this layout now has the facepile + play button on the same row:

<img width="1124" alt="image" src="https://github.com/syntaxfm/website/assets/2153/13f7676d-9105-4ca8-bcce-f0afaa5ecff8">
