### PR TITLE
Fix typo in `--body-font-familly`

### DIFF
--- a/src/styles/buttons.css
+++ b/src/styles/buttons.css
@@ -11,7 +11,7 @@
 		cursor: pointer;
 		text-decoration: none;
 		border: none;
-		font-family: var(--body-font-familly);
+		font-family: var(--body-font-family);
 		font-weight: 600;
 		padding: 6px 15px;
 		font-size: var(--body-font-size);


### PR DESCRIPTION
While working on Wallace's custom property inspector I found there's a typo in `--body-font-familly`. The inspector shows there _is_ a custom prop called `--body-font-family` so I changed the typo to that one.

<img width="1437" alt="Screenshot 2024-01-27 at 10 13 42" src="https://github.com/syntaxfm/website/assets/1536852/03c49169-f452-428b-a08c-7b8d3131dd54">
