### PR TITLE
adds indexes to relational content

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,8 @@ model ShowGuest {
   transcriptId String?
 
   @@unique([showId, guestId])
+  @@index([transcriptId])
+  @@index([guestId])
 }
 
 model Guest {
@@ -145,6 +147,8 @@ model TranscriptUtterance {
   speakerName      String?
   transcript       Transcript                @relation(fields: [transcriptId], references: [id], onDelete: Cascade)
   transcriptId     String
+
+  @@index([transcriptId])
 }
 
 model TranscriptUtteranceWord {
@@ -158,6 +162,8 @@ model TranscriptUtteranceWord {
   punctuated_word       String
   TranscriptUtterance   TranscriptUtterance? @relation(fields: [transcriptUtteranceId], references: [id], onDelete: Cascade)
   transcriptUtteranceId String
+
+  @@index([transcriptUtteranceId])
 }
 
 // AI Show Notes
@@ -182,6 +188,8 @@ model AiSummaryEntry {
   description String?
   showNote    Int
   aiShowNote  AiShowNote @relation(fields: [showNote], references: [id], onDelete: Cascade)
+
+  @@index([showNote])
 }
 
 model AiTweet {
@@ -212,4 +220,6 @@ model Topic {
   name       String
   showNote   Int
   aiShowNote AiShowNote @relation(fields: [showNote], references: [id], onDelete: Cascade)
+
+  @@index([showNote])
 }


### PR DESCRIPTION
Deleting (and I guess Querying) relational content (Transcript → Utterance → Word) was timing out on PlanetScale because it was taking longer than 20s to run the query.

Turns out it's because Prisma in `relationMode = "prisma"` doesn't actually create the foreign keys and PlanetScale doesn't support that. So there were no indexes and made the queries super slow - essentially had to load the entire table and then .filter() it. 

adding indexes makes it much much much faster. This PR does that to the schema, but I also will need to PR them in planetscale. 

<img width="1201" alt="Screenshot 2024-02-16 at 12 42 30 PM" src="https://github.com/syntaxfm/website/assets/176013/eaef0878-ade6-48cd-94cd-b1b58871099e">
