### PR TITLE
feat: strip markdown links in search

### DIFF
--- a/src/lib/search/search.ts
+++ b/src/lib/search/search.ts
@@ -64,12 +64,12 @@ export function search(query: string) {
 			);
 		})
 		.map(({ block }) => {
-			return { 
+			return {
 				...block,
-				// replace md links with the square brackets so the search looks better
-				content: block?.content?.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+				content: block?.content
+					// strip markdown braces but preserve the link text as well as the link, delimited by a hyphen
+					.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1 - $2')
 			};
-
 		}) as (Block & Show)[];
 
 	const results = tree([], blocks).children;

--- a/src/lib/search/search.ts
+++ b/src/lib/search/search.ts
@@ -63,7 +63,14 @@ export function search(query: string) {
 				(a?.block?.breadcrumbs.length || 0) - (b?.block?.breadcrumbs.length || 0) || a.rank - b.rank
 			);
 		})
-		.map(({ block }) => block) as (Block & Show)[];
+		.map(({ block }) => {
+			return { 
+				...block,
+				// replace md links with the square brackets so the search looks better
+				content: block?.content?.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+			};
+
+		}) as (Block & Show)[];
 
 	const results = tree([], blocks).children;
 


### PR DESCRIPTION
FWIW I did look into alternatives, such as using remark, but since this is a webworker there is no access to the document 😢.

Best I can do is this regex appraoch. 

before:
![image](https://github.com/syntaxfm/website/assets/996134/bb69ec30-696d-42c2-a9bd-b6cf394ed155)

after:
<img width="1198" alt="image" src="https://github.com/syntaxfm/website/assets/996134/3e354687-538e-4290-9eb7-cd75b341e07c">
