### PR TITLE
Add heading IDs to show pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
 		"rehype-raw": "^7.0.0",
 		"rehype-stringify": "^10.0.0",
 		"remark-gfm": "^4.0.0",
+		"remark-heading-id": "^1.0.1",
 		"remark-parse": "^11.0.0",
 		"remark-rehype": "^11.1.0",
 		"sk-form-data": "^1.0.1",

--- a/src/routes/(site)/show/[show_number]/[slug]/+layout.server.ts
+++ b/src/routes/(site)/show/[show_number]/[slug]/+layout.server.ts
@@ -1,6 +1,7 @@
 import remarkGfm from 'remark-gfm';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
+import remarkHeadingId from 'remark-heading-id';
 import remarkRehype from 'remark-rehype';
 import rehypeRaw from 'rehype-raw';
 import rehypeStringify from 'rehype-stringify';
@@ -49,6 +50,7 @@ export const load = async function ({ params, locals, url }) {
 
 	const body_excerpt = await unified()
 		.use(remarkParse)
+		.use(remarkHeadingId)
 		.use(remarkGfm)
 		.use(remarkRehype, { allowDangerousHtml: true })
 		.use(rehypeRaw)


### PR DESCRIPTION
Wanted to link to a sick pick, but you don't have IDs. This PR (hopefully) fixes this. (I honestly didn't actually test it.)

![Screenshot 2024-02-23 at 17 17 18](https://github.com/syntaxfm/website/assets/145676/cfe40a3b-f88b-43ad-9f3f-2503797f759c)
