### PR TITLE
DRAFT: #1446 - Episode Page: Next/Previous buttons

### DIFF
--- a/src/routes/(site)/show/[show_number]/[slug]/+layout.svelte
+++ b/src/routes/(site)/show/[show_number]/[slug]/+layout.svelte
@@ -38,8 +38,8 @@
 
 <header>
 	<div class="pagination-buttons">
-		<a href={`/${show.number - 1}`}> PREVIOUS </a>
-		<a href={`/${show.number + 1}`}> NEXT </a>
+		<a href={`/show/${show.number - 1}/${show.slug}`}> PREVIOUS </a>
+		<a href={`/show/${show.number + 1}/${show.slug}`}> NEXT </a>
 	</div>
 	<span
 		title="Show #{show.number}"

--- a/src/routes/(site)/show/[show_number]/[slug]/+layout.svelte
+++ b/src/routes/(site)/show/[show_number]/[slug]/+layout.svelte
@@ -37,6 +37,10 @@
 </script>
 
 <header>
+	<div class="pagination-buttons">
+		<a href={`/show/${show.number - 1}/${show.slug}`}> PREVIOUS </a>
+		<a href={`/show/${show.number + 1}/${show.slug}`}> NEXT </a>
+	</div>
 	<span
 		title="Show #{show.number}"
 		style:--transition-name="show-date-{show.number}"
@@ -232,6 +236,39 @@
 			gap: 8px;
 			span {
 				margin-inline: 5px;
+			}
+		}
+
+		.pagination-buttons {
+			display: flex;
+			gap: 0 1rem;
+
+			a {
+				display: block;
+				text-decoration: none;
+				background: var(--nav_a_bg, rgba(255, 255, 255, 0.0786987545689));
+				padding: 10px 20px;
+				@media (--below_large) {
+					padding: 8px 16px;
+					font-size: var(--font-size-xs);
+				}
+				border: 0;
+				border-radius: 20px;
+				align-items: center;
+				display: none;
+				max-width: 100;
+				&:hover {
+					border: 0;
+					background: var(--primary);
+					color: var(--bg);
+				}
+				&.active {
+					background-color: var(--primary);
+					color: var(--bg);
+				}
+				@media (--above_med) {
+					display: block;
+				}
 			}
 		}
 	}

--- a/src/routes/(site)/show/[show_number]/[slug]/+layout.svelte
+++ b/src/routes/(site)/show/[show_number]/[slug]/+layout.svelte
@@ -38,8 +38,8 @@
 
 <header>
 	<div class="pagination-buttons">
-		<a href={`/show/${show.number - 1}/${show.slug}`}> PREVIOUS </a>
-		<a href={`/show/${show.number + 1}/${show.slug}`}> NEXT </a>
+		<a href={`/${show.number - 1}`}> PREVIOUS </a>
+		<a href={`/${show.number + 1}`}> NEXT </a>
 	</div>
 	<span
 		title="Show #{show.number}"


### PR DESCRIPTION
This should add the next and previous buttons to the Episode Page.

Two things to fix before merging:
1. Styling. I just threw these elements in here.
2. We started this [convo over here](https://github.com/syntaxfm/website/issues/1446) but `/show/${show.number - 1}/${show.slug}` is not accurately using the next and previous `show.slug`. There just _has_ to be a value there or we redirect to the `/shows` page. We will navigate to the correct page and the URL will update but the href is never the correct value.