### PR TITLE
fix global variables with theme switcher

### DIFF
--- a/src/routes/(site)/+layout.svelte
+++ b/src/routes/(site)/+layout.svelte
@@ -65,7 +65,7 @@
 
 <style lang="postcss">
 	:global(.theme-wrapper) {
-		--bg-root: var(--bg, orange);
+		--bg-root: var(--bg);
 		--fg-root: var(--fg);
 		min-height: 100vh;
 		border-top: var(--border);

--- a/src/routes/(site)/+layout.svelte
+++ b/src/routes/(site)/+layout.svelte
@@ -64,8 +64,8 @@
 </div>
 
 <style lang="postcss">
-	.theme-wrapper {
-		--bg-root: var(--bg);
+	:global(.theme-wrapper) {
+		--bg-root: var(--bg, orange);
 		--fg-root: var(--fg);
 		min-height: 100vh;
 		border-top: var(--border);


### PR DESCRIPTION
when switching themes, we remove the svelte created unique class - thus the .theme-wrapper styles aren't applied until a full refresh. 

These variables need to be global, and not with a generated class name. 

Fixes #1584 