### PR TITLE
feat: show video duration

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -234,6 +234,7 @@ model Video {
   url          String
   published_at DateTime
   thumbnail    String
+  duration     String            @default("00:00")
   slug         String            @unique
   playlists    PlaylistOnVideo[]
   shows        ShowVideo[]

--- a/src/lib/videos/PlaylistVideo.svelte
+++ b/src/lib/videos/PlaylistVideo.svelte
@@ -7,7 +7,12 @@
 
 <div>
 	<a href={`/videos/${playlist.slug}/${video.slug}`}>
-		<img src={video.thumbnail} class="thumbnail" alt={video.title} />
+		<div class="thumbnail-wrapper">
+			<img src={video.thumbnail} class="thumbnail" alt={video.title} />
+			{#if video.duration}
+				<span class="duration">{video.duration}</span>
+			{/if}
+		</div>
 		<h3 class="h6">{video.title}</h3>
 	</a>
 </div>
@@ -23,9 +28,25 @@
 		margin-top: 0;
 	}
 
-	.thumbnail {
-		overflow: hidden;
-		border-radius: var(--brad);
+	
+	.thumbnail-wrapper {
+		position: relative;
+		
+		.thumbnail {
+			overflow: hidden;
+			border-radius: var(--brad);
+		}
+		.duration {
+			position: absolute;
+			display: inline-block;
+			background: var(--yellow);
+			color: var(--black);
+			border-radius: 1rem;
+			padding: 0.25rem;
+			right: 1rem;
+			top: 1rem;
+			font-weight: 600;
+		}
 	}
 
 	img {

--- a/src/lib/videos/parseDuration.ts
+++ b/src/lib/videos/parseDuration.ts
@@ -1,0 +1,16 @@
+// Match one part of the duration string at a time and pad with 0
+// Avoids a complex / hard to understand regex for matching all parts at once
+function parseTime(duration: string, part: 'H' | 'M' | 'S') {
+	const match = duration.match(new RegExp(`(\\d+)${part}`));
+	return match ? match[1].padStart(1, '0') : '00';
+}
+
+// Parses duration from YouTube duration format (ISO 8601) e.g. PT1H14M28S to 01:14:28
+export default function parseDuration(duration: string) {
+	const hours = parseTime(duration, 'H');
+	const minutes = parseTime(duration, 'M');
+	const seconds = parseTime(duration, 'S');
+
+	const result = `${minutes}:${seconds}`;
+	return hours !== '00' ? `${hours}:${duration}` : result;
+}

--- a/src/routes/(site)/videos/[p_slug]/+page.svelte
+++ b/src/routes/(site)/videos/[p_slug]/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import PlaylistVideo from "$/lib/videos/PlaylistVideo.svelte";
+
 	export let data;
 	$: ({ playlist } = data);
 </script>
@@ -7,21 +9,12 @@
 	<h1 class="h3">{playlist.title}</h1>
 	<div class="playlist-grid grid">
 		{#each playlist.videos as { video }}
-			<a href={`/videos/${playlist.slug}/${video.slug}`}>
-				<img src={video.thumbnail} class="thumbnail" alt={video.title} />
-				<h3 class="h6">{video.title}</h3>
-			</a>
+			<PlaylistVideo {playlist} {video} />
 		{/each}
 	</div>
 {/if}
 
 <style lang="postcss">
-	img {
-		width: 100%;
-	}
-	.h6 {
-		margin-bottom: 0;
-	}
 	.playlist-grid {
 		display: grid;
 		grid-gap: 20px;


### PR DESCRIPTION
* Save video duration to DB when importing from YouTube API
* Show duration on video thumbnail on the all playlists page and the single playlist page

![Screenshot 2024-03-29 at 9 31 36 AM](https://github.com/syntaxfm/website/assets/14241866/181847be-cc12-4d9c-847c-c60875a97f10)
