### PR TITLE
feat: playlist order fix: #1622

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -239,6 +239,16 @@ model Video {
   shows        ShowVideo[]
 }
 
+enum PlaylistOrder {
+  // Use playlist order as it is on YouTube
+  YouTubeAsc
+  // Reverse playlist order as it is on YouTube
+  YouTubeDesc
+  // Order playlist by video publish date accordingly
+  VideoPublishedAtAsc
+  VideoPublishedAtDesc
+}
+
 model Playlist {
   id          String            @id @default(uuid())
   title       String
@@ -246,6 +256,7 @@ model Playlist {
   created_at  DateTime          @default(now())
   slug        String            @unique
   unlisted    Boolean?          @default(false)
+  order       PlaylistOrder     @default(YouTubeAsc)
   videos      PlaylistOnVideo[]
 }
 

--- a/src/lib/videos/playlistOrderBy.ts
+++ b/src/lib/videos/playlistOrderBy.ts
@@ -1,0 +1,20 @@
+import { PlaylistOrder } from '@prisma/client';
+
+export default {
+	[PlaylistOrder.YouTubeAsc]: {
+		order: 'asc'
+	},
+	[PlaylistOrder.YouTubeDesc]: {
+		order: 'desc'
+	},
+	[PlaylistOrder.VideoPublishedAtDesc]: {
+		video: {
+			published_at: 'desc'
+		}
+	},
+	[PlaylistOrder.VideoPublishedAtAsc]: {
+		video: {
+			published_at: 'asc'
+		}
+	}
+} as const;

--- a/src/routes/(site)/admin/videos/[playlist_id]/+page.server.ts
+++ b/src/routes/(site)/admin/videos/[playlist_id]/+page.server.ts
@@ -1,3 +1,6 @@
+import { PlaylistOrder } from '@prisma/client';
+import type { Actions } from '@sveltejs/kit';
+
 export const load = async ({ params, locals }) => {
 	const { playlist_id } = params;
 
@@ -29,15 +32,42 @@ export const load = async ({ params, locals }) => {
 		const videos = playlist.videos.map((item) => item.video);
 		console.log('videos', videos);
 
+		const playlistOrderTypes = Object.keys(PlaylistOrder);
+
 		return {
 			playlist,
-			videos
+			videos,
+			playlistOrderTypes
 		};
 	} catch (error) {
 		console.error('Error fetching playlist videos:', error);
 		return {
 			status: 500,
 			error: 'Internal Server Error'
+		};
+	}
+};
+
+export const actions: Actions = {
+	updatePlaylist: async function updatePlaylist({ locals, params }) {
+		const { playlist_id } = params;
+		const { playlistOrder } = locals.form_data;
+		if (!playlist_id || !playlistOrder) {
+			return {
+				error: 'Missing data',
+				status: 500
+			};
+		}
+		await locals.prisma.playlist.update({
+			where: {
+				id: playlist_id
+			},
+			data: {
+				order: locals.form_data.playlistOrder as PlaylistOrder
+			}
+		});
+		return {
+			message: 'Updated'
 		};
 	}
 };

--- a/src/routes/(site)/admin/videos/[playlist_id]/+page.svelte
+++ b/src/routes/(site)/admin/videos/[playlist_id]/+page.svelte
@@ -1,10 +1,12 @@
 <!-- src/routes/playlists/[playlist_id]/+page.svelte -->
 <script lang="ts">
 	import AdminSearch from '$/lib/AdminSearch.svelte';
+	import { enhance } from '$app/forms';
+	import { form_action } from '$lib/form_action';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
-	const { playlist, videos } = data;
+	const { playlist, videos, playlistOrderTypes } = data;
 
 	let search_text = '';
 
@@ -12,6 +14,20 @@
 </script>
 
 <h1>{playlist?.title}</h1>
+
+{#if playlistOrderTypes}
+	<form use:enhance={form_action({ message: 'Update Playlist Order' })} action="?/updatePlaylist" method="POST">
+		<label>
+			Order Playlist
+			<select name="playlistOrder" value={playlist?.order}>
+				{#each playlistOrderTypes as orderType}
+					<option>{orderType}</option> 
+				{/each}
+			</select>
+		</label>
+		<button>Update</button>
+	</form>
+{/if}
 
 <div>
 	<AdminSearch bind:text={search_text} />
@@ -42,3 +58,9 @@
 		</table>
 	</div>
 </div>
+
+<style>
+	form {
+		margin: 1rem;
+	}
+</style>

--- a/src/routes/(site)/videos/+page.server.ts
+++ b/src/routes/(site)/videos/+page.server.ts
@@ -1,29 +1,42 @@
+import playListOrderBy from '$lib/videos/playlistOrderBy';
+
 export const load = async function ({ locals }) {
-	const playlists = await locals.prisma.playlist.findMany({
+	const playlistMeta = await locals.prisma.playlist.findMany({
 		orderBy: {
 			created_at: 'desc'
 		},
-		include: {
-			videos: {
-				take: 3,
-				orderBy: {
-					order: 'asc'
-				},
-				include: {
-					video: true
-				}
-			},
-			_count: {
-				select: {
-					videos: true
-				}
-			}
+		select: {
+			id: true,
+			order: true
 		}
 	});
+	const playlists = await Promise.all(
+		playlistMeta.map(async (playlist) => {
+			return locals.prisma.playlist.findFirst({
+				where: {
+					id: playlist.id
+				},
+				include: {
+					videos: {
+						take: 3,
+						orderBy: playListOrderBy[playlist.order],
+						include: {
+							video: true
+						}
+					},
+					_count: {
+						select: {
+							videos: true
+						}
+					}
+				}
+			});
+		})
+	);
 
 	const playlists_with_item_count = playlists.map((playlist) => ({
 		...playlist,
-		item_count: playlist._count.videos
+		item_count: playlist!._count.videos
 	}));
 	return {
 		playlists: playlists_with_item_count

--- a/src/routes/(site)/videos/[p_slug]/+page.server.ts
+++ b/src/routes/(site)/videos/[p_slug]/+page.server.ts
@@ -1,23 +1,36 @@
+import playlistOrderBy from '$/lib/videos/playlistOrderBy.js';
+
 export const load = async function ({ locals, params }) {
 	const { p_slug } = params;
-	const playlist = await locals.prisma.playlist.findUnique({
+	const playlistMeta = await locals.prisma.playlist.findUnique({
 		where: { slug: p_slug },
-		include: {
-			videos: {
-				include: {
-					video: true
-				}
-			}
+		select: {
+			id: true,
+			order: true
 		}
 	});
 
-	if (!playlist) {
+	if (!playlistMeta) {
 		// Playlist not found
 		return {
 			status: 404,
 			error: 'Playlist not found'
 		};
 	}
+
+	const playlist = await locals.prisma.playlist.findUnique({
+		where: {
+			id: playlistMeta.id
+		},
+		include: {
+			videos: {
+				include: {
+					video: true
+				},
+				orderBy: playlistOrderBy[playlistMeta.order]
+			}
+		}
+	});
 
 	return {
 		playlist


### PR DESCRIPTION
This addresses #1622

Introduced a PlaylistOrder enum to the Playlist model. I thought this might be useful because some playlists we might want to keep ordering exactly as it is on YouTube, some should be reversed and some should be sorted by video published asc / desc.

If this is too complex we can just go with order by Video Published desc

This PR:
* Allows admins to set playlist sort from playlist admin page
* Ordering type is used on playlists overview page and individual playlist page

What needs review:
* This introduces extra queries when getting a playlist, since we have to get the preferred order type from the playlist table _first_ before querying for included videos to set the orderBy property. Seems fine for just a few playlists, but when we have many, this could start to slow the page load down.


https://github.com/syntaxfm/website/assets/14241866/cb76dd98-ae76-4f4d-89bb-d5434eec0656

