### PR TITLE
chore: move plausible proxy to api routes

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -10,8 +10,8 @@
 		<script
 			defer
 			data-domain="syntax.fm"
-			data-api="/57475/4p1/3v3n7"
-			src="/57475/j5/script.js"
+			data-api="/api/57475/3v3n7"
+			src="/api/57475/script.js"
 		></script>
 
 		%sveltekit.head%

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -105,8 +105,9 @@ export const document_policy: Handle = async function ({ event, resolve }) {
 	return response;
 };
 
+const safe_paths = new Set(['/api/errors', '/api/57475/3v3n7']);
 export const safe_form_data: Handle = async function ({ event, resolve }) {
-	if (event.url.pathname === '/api/errors') return resolve(event);
+	if (safe_paths.has(event.url.pathname)) return resolve(event);
 	return form_data({ event, resolve });
 };
 

--- a/src/routes/api/57475/3v3n7/+server.ts
+++ b/src/routes/api/57475/3v3n7/+server.ts
@@ -1,0 +1,29 @@
+import type { RequestHandler } from '@sveltejs/kit';
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	const body = await request.text();
+	const response = await fetch('https://plausible.io/api/event', {
+		method: 'POST',
+		body,
+		headers: {
+			'User-Agent': request.headers.get('user-agent') || 'unknown',
+			'Content-Type': 'application/json',
+			'X-Forwarded-For': locals.session.ip
+		}
+	});
+	const responseBody = await response.text();
+	if (!response.ok) {
+		console.error('Error proxying plausible event:', {
+			status: response.status,
+			statusText: response.statusText,
+			body: responseBody
+		});
+	}
+	return new Response(responseBody, {
+		status: response.status,
+		statusText: response.statusText,
+		headers: {
+			'Content-Type': response.headers.get('content-type') || 'text/plain'
+		}
+	});
+};

--- a/src/routes/api/57475/script.js/+server.ts
+++ b/src/routes/api/57475/script.js/+server.ts
@@ -1,0 +1,12 @@
+import type { RequestHandler } from '@sveltejs/kit';
+
+export const GET: RequestHandler = async () => {
+	const response = await fetch('https://plausible.io/js/script.js');
+	return new Response(await response.text(), {
+		headers: {
+			'content-type': 'application/javascript',
+			'cache-control':
+				response.headers.get('cache-control') || 'public, must-revalidate, max-age=86400'
+		}
+	});
+};

--- a/vercel.json
+++ b/vercel.json
@@ -14,15 +14,5 @@
 			"path": "/webhooks/ai",
 			"schedule": "*/5 * * * *"
 		}
-	],
-	"rewrites": [
-    {
-      "source": "/57475/j5/script.js",
-      "destination": "https://plausible.io/js/script.js"
-    },
-    {
-      "source": "/57475/4p1/3v3n7",
-      "destination": "https://plausible.io/api/event"
-    }
-  ]
+	]
 }


### PR DESCRIPTION
* Before, the plausible events were proxied via the `vercel.json` which would only work when deployed to vercel or when running `vercel dev` locally
* Now, the events are proxied through custom API routes, so they will work in dev and when deployed