### PR TITLE
bug: revert plausible analytics change

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -10,8 +10,8 @@
 		<script
 			defer
 			data-domain="syntax.fm"
-			data-api="/api/57475/3v3n7"
-			src="/api/57475/script.js"
+			data-api="/57475/4p1/3v3n7"
+			src="/57475/j5/script.js"
 		></script>
 
 		%sveltekit.head%

--- a/vercel.json
+++ b/vercel.json
@@ -14,5 +14,15 @@
 			"path": "/webhooks/ai",
 			"schedule": "*/5 * * * *"
 		}
-	]
+	],
+	"rewrites": [
+    {
+      "source": "/57475/j5/script.js",
+      "destination": "https://plausible.io/js/script.js"
+    },
+    {
+      "source": "/57475/4p1/3v3n7",
+      "destination": "https://plausible.io/api/event"
+    }
+  ]
 }


### PR DESCRIPTION
* TLDR: we lost about 2 days worth of analytics because some users of the site are hitting a cached back-end function that doesn't have the updated proxy code

* [This error](https://syntax-fm.sentry.io/issues/5146658009/?query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=3) showed up in sentry
* The error `Could not parse content as FormData.` happens when the [hooks.server.ts](https://github.com/syntaxfm/website/blob/main/src/hooks.server.ts#L110) does not have the updated safe_form_data handle to skip parsing the body as form-data
  * I'm baffled that a back-end function can be cached like this but I guess that's something that can happen on vercel?
 
* I'm reverting my proxy changes to go back to the `vercel.json` file for now 
 