### PR TITLE
chore: add error handling and options requests

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -10,8 +10,8 @@
 		<script
 			defer
 			data-domain="syntax.fm"
-			data-api="/57475/4p1/3v3n7"
-			src="/57475/j5/script.js"
+			data-api="/api/57475/3v3n7"
+			src="/api/57475/script.js"
 		></script>
 
 		%sveltekit.head%

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -108,7 +108,17 @@ export const document_policy: Handle = async function ({ event, resolve }) {
 const safe_paths = new Set(['/api/errors', '/api/57475/3v3n7']);
 export const safe_form_data: Handle = async function ({ event, resolve }) {
 	if (safe_paths.has(event.url.pathname)) return resolve(event);
-	return form_data({ event, resolve });
+	const contentType = event.request.headers.get('content-type');
+	if (contentType?.includes('form-data')) {
+		try {
+			const result = await form_data({ event, resolve });
+			return result;
+		} catch (error) {
+			console.error('Error parsing form-data:');
+			console.error(error);
+		}
+	}
+	return resolve(event);
 };
 
 // * END HOOKS

--- a/src/routes/api/errors/+server.ts
+++ b/src/routes/api/errors/+server.ts
@@ -1,7 +1,10 @@
 import type { RequestHandler } from '@sveltejs/kit';
+import optionsHandler from '../optionsHandler';
 
 const SENTRY_HOST = 'o4505358925561856.ingest.sentry.io';
 const SENTRY_PROJECT_IDS = ['4505358945419264'];
+
+export const OPTIONS = optionsHandler();
 
 export const POST: RequestHandler = async ({ request }) => {
 	try {
@@ -25,6 +28,10 @@ export const POST: RequestHandler = async ({ request }) => {
 		return Response.json({}, { status: 200 });
 	} catch (e) {
 		console.error('error tunneling to sentry', e);
-		return Response.json({ error: 'error tunneling to sentry' }, { status: 500 });
+		let message: string | undefined = undefined;
+		if (e instanceof Error) {
+			message = e.message;
+		}
+		return Response.json({ error: 'error tunneling to sentry', message }, { status: 500 });
 	}
 };

--- a/src/routes/api/optionsHandler.ts
+++ b/src/routes/api/optionsHandler.ts
@@ -1,0 +1,18 @@
+import type { RequestHandler } from '@sveltejs/kit';
+
+const optionsHandler = (methods: string = 'OPTIONS,POST') => {
+	const options: RequestHandler = async ({ request }) => {
+		return new Response(null, {
+			headers: {
+				'Access-Control-Allow-Credentials': 'true',
+				'Access-Control-Allow-Origin': request.headers.get('origin') || 'syntax.fm',
+				'Access-Control-Allow-Methods': methods,
+				'Access-Control-Allow-Headers':
+					'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version'
+			}
+		});
+	};
+	return options;
+};
+
+export default optionsHandler;

--- a/vercel.json
+++ b/vercel.json
@@ -14,15 +14,5 @@
 			"path": "/webhooks/ai",
 			"schedule": "*/5 * * * *"
 		}
-	],
-	"rewrites": [
-    {
-      "source": "/57475/j5/script.js",
-      "destination": "https://plausible.io/js/script.js"
-    },
-    {
-      "source": "/57475/4p1/3v3n7",
-      "destination": "https://plausible.io/api/event"
-    }
-  ]
+	]
 }


### PR DESCRIPTION
* Reverts to using API functions for plausible analytics
* Updates `src/hooks.server.ts` to only call `form_data` if the content-type is form-data AND wraps the call in a try catch
  * Any other type of POST request that comes into the app will 404 instead of failing to parse
* Updates plausible API function to forward error to Sentry if the call to plausible fails
* Updates sentry API function to include error message if proxy to sentry fails
* Adds OPTIONS request to both plausible and sentry proxy
  * There were a few 404s in the logs for clients that were trying OPTIONS before making a POST request