### PR TITLE
fix(652): correct invalid frontmatter

### DIFF
--- a/shows/652 - Supper.md
+++ b/shows/652 - Supper.md
@@ -5,7 +5,7 @@ date: 1691755200455
 url: https://traffic.libsyn.com/syntax/Syntax_-_652.mp3
 guest:
   name: Brandon Bayer
-  if: Flightcontrol
+  of: Flightcontrol
   github: flybayer
   twitter: flybayer
   url: https://www.flightcontrol.dev/


### PR DESCRIPTION
## Description

As part of my other pull request, I noticed some invalid frontmatter errors in the console.

![CleanShot 2024-04-30 at 21 36 26@2x](https://github.com/syntaxfm/website/assets/7691252/f0f48e11-e147-4686-b0b6-a49972f67268)

## Before vs After

<img src="https://github.com/syntaxfm/website/assets/7691252/6b0b7e94-8864-4fb7-a599-f4d9bfe86fb0" width="200px" />

<img src="https://github.com/syntaxfm/website/assets/7691252/aab23e4a-d165-4555-8f4f-923cabb3068d" width="200px" />
