### PR TITLE
feat: Swap to Codecov SvelteKit plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"postinstall": "pnpm db:generate && pnpm exec playwright install"
 	},
 	"devDependencies": {
-		"@codecov/vite-plugin": "0.0.1-beta.6",
+		"@codecov/sveltekit-plugin": "0.0.1-beta.9",
 		"@playwright/test": "^1.42.1",
 		"@sveltejs/kit": "^2.5.5",
 		"@sveltejs/vite-plugin-svelte": "^3.0.2",
@@ -109,5 +109,9 @@
 	},
 	"prisma": {
 		"seed": "node --loader ts-node/esm prisma/seed.ts"
+	},
+	"volta": {
+		"node": "20.14.0",
+		"pnpm": "8.1.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,9 +139,9 @@ dependencies:
     version: 7.2.3
 
 devDependencies:
-  '@codecov/vite-plugin':
-    specifier: 0.0.1-beta.6
-    version: 0.0.1-beta.6(vite@5.2.8)
+  '@codecov/sveltekit-plugin':
+    specifier: 0.0.1-beta.9
+    version: 0.0.1-beta.9(@sveltejs/kit@2.5.5)(svelte@4.2.12)(vite@5.2.8)
   '@playwright/test':
     specifier: ^1.42.1
     version: 1.42.1
@@ -290,8 +290,8 @@ packages:
       to-fast-properties: 2.0.0
     dev: false
 
-  /@codecov/bundler-plugin-core@0.0.1-beta.6:
-    resolution: {integrity: sha512-dGk/s90fZm7D1O00gRtuE2gqM/CW9nglaPzcIT0v10VOV2tj+aHRrdB+yjas+RW8QP8Qf/sMqSmjkufP1iqggw==}
+  /@codecov/bundler-plugin-core@0.0.1-beta.9:
+    resolution: {integrity: sha512-zxMpUhhplvjuwNVmLtOi64d7LGPAhoLsQwVky9Rkx8oRHaDKqDvuisrs+NP5mIE9tQYPnGZKgiv0gnEJ3AHULw==}
     engines: {node: '>=18.0.0'}
     dependencies:
       chalk: 4.1.2
@@ -300,13 +300,30 @@ packages:
       zod: 3.22.4
     dev: true
 
-  /@codecov/vite-plugin@0.0.1-beta.6(vite@5.2.8):
-    resolution: {integrity: sha512-eIi3M9R1om/T+6FoZGaffWMmwSZ0nx1fIGgidFRFkQdXtKAwHU0//YjCXOg17vJsPXlaSatM81EQBU/qmSXQ1Q==}
+  /@codecov/sveltekit-plugin@0.0.1-beta.9(@sveltejs/kit@2.5.5)(svelte@4.2.12)(vite@5.2.8):
+    resolution: {integrity: sha512-wAp1IenXKNfFGrnsfts1xRRANMfoDUrXA2JgJmHu52Uj0ZAKKBqxWlByVvji7cBEYSI9GYoYfQsC4C7iHDPfkg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@sveltejs/kit': 2.x
+      svelte: 4.x
+    dependencies:
+      '@codecov/bundler-plugin-core': 0.0.1-beta.9
+      '@codecov/vite-plugin': 0.0.1-beta.9(vite@5.2.8)
+      '@sveltejs/kit': 2.5.5(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.12)(vite@5.2.8)
+      svelte: 4.2.12
+      unplugin: 1.10.1
+    transitivePeerDependencies:
+      - vite
+    dev: true
+
+  /@codecov/vite-plugin@0.0.1-beta.9(vite@5.2.8):
+    resolution: {integrity: sha512-SbJagAnmiFb1YRdTjDOt5fisc7GTRLPJIbth/rvSFIuX9HZLM0Effb/XniLBQrD/IL5znL/7e75Lhcez2ryKnA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       vite: 4.x || 5.x
     dependencies:
-      '@codecov/bundler-plugin-core': 0.0.1-beta.6
+      '@codecov/bundler-plugin-core': 0.0.1-beta.9
+      unplugin: 1.10.1
       vite: 5.2.8(@types/node@20.12.3)
     dev: true
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,7 @@
-// import { sentrySvelteKit } from '@sentry/sveltekit';
 import { sentrySvelteKit } from '@sentry/sveltekit';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vitest/config';
-import { codecovVitePlugin } from '@codecov/vite-plugin';
+import { codecovSvelteKitPlugin } from '@codecov/sveltekit-plugin';
 import { loadEnv } from 'vite';
 
 export default defineConfig(({ mode }) => {
@@ -19,7 +18,7 @@ export default defineConfig(({ mode }) => {
 				}
 			}),
 			sveltekit(),
-			codecovVitePlugin({
+			codecovSvelteKitPlugin({
 				enableBundleAnalysis: env.CODECOV_TOKEN !== undefined,
 				bundleName: 'website',
 				uploadToken: env.CODECOV_TOKEN


### PR DESCRIPTION
Swapping to use `@codecov/sveltekit-plugin`, which offers support for both client and server bundles.