### PR TITLE
add dotenv-expand; add create/update to preheat

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ That's it!
      ```
 1. If using docker, in a separate tab run -> `docker compose up`
 1. Run -> `pnpm preheat`
-1. Run -> `pnpm db:push`
 1. Run -> `pnpm dev`
 1. Visit `http://localhost:5173`
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
 		"chroma-js": "^2.4.2",
 		"core-js": "^3.37.1",
 		"date-fns": "^3.6.0",
+		"dotenv-expand": "^11.0.6",
 		"flexsearch": "^0.7.43",
 		"gpt-3-encoder": "^1.1.4",
 		"gray-matter": "^4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
+      dotenv-expand:
+        specifier: ^11.0.6
+        version: 11.0.6
       flexsearch:
         specifier: ^0.7.43
         version: 0.7.43
@@ -1729,6 +1732,10 @@ packages:
 
   domutils@3.1.0:
     resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
+
+  dotenv-expand@11.0.6:
+    resolution: {integrity: sha512-8NHi73otpWsZGBSZwwknTXS5pqMOrk9+Ssrna8xCaxkzEpU9OTf9R5ArQGVw03//Zmk9MOwLPng9WwndvpAJ5g==}
+    engines: {node: '>=12'}
 
   dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
@@ -5642,6 +5649,10 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  dotenv-expand@11.0.6:
+    dependencies:
+      dotenv: 16.4.5
 
   dotenv@16.4.5: {}
 

--- a/scripts/preheat.js
+++ b/scripts/preheat.js
@@ -4,10 +4,11 @@ import { promises as fs } from 'fs';
 import { execSync } from 'child_process';
 import { createConnection } from 'mysql2/promise';
 import dotenv from 'dotenv';
+import { expand } from 'dotenv-expand';
 import semver from 'semver';
 
 // Load environment variables
-dotenv.config();
+expand(dotenv.config());
 
 async function main() {
 	const args = process.argv.slice(2);
@@ -24,6 +25,7 @@ async function main() {
 		await checkPnpmVersion();
 		await checkAndUpdateEnv();
 		checkDatabaseUrl();
+		await createUpdateSchema();
 		await checkShowTableData();
 		console.log('🥘 Website preheated to 450°F (232°C)');
 		execSync('pnpm vite dev', { stdio: 'inherit' });
@@ -98,6 +100,15 @@ function checkDatabaseUrl() {
 		throw new Error('❌ Please set DATABASE_URL in .env to be a proper mysql url');
 	}
 	console.log('✅ DATABASE_URL Check');
+}
+
+async function createUpdateSchema() {
+	try {
+		execSync('pnpm db:push', { stdio: 'inherit' });
+		console.log('✅ Database schema created / updated');
+	} catch {
+		throw new Error('❌ Unable to create / update DB schema');
+	}
 }
 
 async function checkShowTableData() {


### PR DESCRIPTION
* Adds `dotenv-expand` so I can use this syntax in my `.env`:

```sh
DATABASE_URL=mysql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}
```

* Adds `pnpm db:push` to the preheat script to create the schema in the DB before seeding