### PR TITLE
Check for admin privileges

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -66,6 +66,16 @@ export const auth: Handle = async function ({ event, resolve }) {
 	return response;
 };
 
+export const admin: Handle = async function ({ event, resolve }) {
+	if (
+		event.route.id?.startsWith('/(site)/admin') &&
+		!event.locals?.user?.roles?.includes('admin')
+	) {
+		throw redirect(302, '/login');
+	}
+	return resolve(event);
+};
+
 // This hook is used to pass our prisma instance to each action, load, and endpoint
 export const prisma: Handle = async function ({ event, resolve }) {
 	const ip = event.request.headers.get('x-forwarded-for') as string;
@@ -128,6 +138,7 @@ export const handle: Handle = sequence(
 	Sentry.sentryHandle(),
 	prisma,
 	auth,
+	admin,
 	safe_form_data,
 	redirects,
 	document_policy

--- a/src/routes/(site)/admin/+layout.server.ts
+++ b/src/routes/(site)/admin/+layout.server.ts
@@ -1,5 +1,0 @@
-import { redirect } from '@sveltejs/kit';
-
-export const load = async function ({ locals }) {
-	if (!locals?.user?.roles?.includes('admin')) redirect(302, '/login');
-};

--- a/tests/default.test.ts
+++ b/tests/default.test.ts
@@ -1,9 +1,12 @@
 import { expect, test } from '@playwright/test';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
 
 test('index page has expected h1', async ({ page }) => {
 	await page.goto('/');
 	await expect(
-		page.getByRole('heading', { name: 'A Tasty Treats Podcast for Web Developers' })
+		page.getByRole('heading', { name: 'Tasty Treats for Web Developers' })
 	).toBeVisible();
 });
 
@@ -12,6 +15,23 @@ test('Got about page', async ({ page }) => {
 	await page.click('a:has-text("About")');
 	// Check for an h1 with the text "All Episodes"
 	await expect(page.locator('h1:has-text("About Syntax")')).toBeVisible();
+});
+
+test('admin action should require login', async ({ request, baseURL }) => {
+	const response = await request.post(`/admin/shows?/delete_all_shows`, {
+		headers: {
+			'Content-Type': 'multipart/form-data',
+			Origin: `${baseURL}`
+		}
+	});
+
+	expect(response.ok()).toBeTruthy();
+	const body = await response.json();
+	expect(body.status).toBe(302);
+	expect(body.location).toBe('/login');
+
+	const result = await prisma.guest.findMany();
+	expect(result.length).not.toBe(0);
 });
 
 test('Got to podcast detail page', async ({ page }) => {


### PR DESCRIPTION
Checking for admin privileges in the layout loader does not prevent the action from running as loaders run after the action. It must be checked in the action itself. To avoid duplicating for every action I've added it as a hook instead.

This does not test the actual admin role or a positive check that the action does run for admin. To do that we would need to create a session and it seems like the database does not get reseeded on each test run.