### PR TITLE
adds cache header to search content.json

### DIFF
--- a/src/routes/content.json/+server.ts
+++ b/src/routes/content.json/+server.ts
@@ -3,7 +3,14 @@ import { json } from '@sveltejs/kit';
 
 export async function GET() {
 	const data = await content();
-	return json({
-		blocks: data
-	});
+	return json(
+		{
+			blocks: data
+		},
+		{
+			headers: {
+				'cache-control': `public s-maxage=${60 * 60 * 5}`
+			}
+		}
+	);
 }


### PR DESCRIPTION
Been blowing through our "fast" bandwidth on vercel because this file isn't cached. Easy fix.

<img width="924" alt="Screenshot 2024-07-15 at 9 46 50 AM" src="https://github.com/user-attachments/assets/205a42c4-39f9-4f39-9dd7-6917a6fecfd2">
