### PR TITLE
fixes incorrect shared cache max age header

### DIFF
--- a/src/routes/(blank)/og/[show_number].jpg/+server.ts
+++ b/src/routes/(blank)/og/[show_number].jpg/+server.ts
@@ -49,7 +49,7 @@ export const config = {
 const headers = {
 	'Content-Type': 'image/jpeg',
 	// cache for 10 minutes, allow stale to be served for up for another 10 mins
-	'cache-control': 'public s-max-age=600, stale-while-revalidate=600'
+	'cache-control': 'public s-maxage=600, stale-while-revalidate=600'
 };
 
 export async function GET({ url, params }) {

--- a/src/routes/(site)/show/[show_number]/[slug]/+page.server.ts
+++ b/src/routes/(site)/show/[show_number]/[slug]/+page.server.ts
@@ -4,7 +4,7 @@ export const load = async function ({ setHeaders, parent }) {
 	const { show } = await parent();
 	const cache_ms = get_show_cache_s(show.date);
 	setHeaders({
-		'cache-control': `public s-max-age=${cache_ms}, stale-while-revalidate=${cache_ms}`
+		'cache-control': `public s-maxage=${cache_ms}, stale-while-revalidate=${cache_ms}`
 	});
 	return {};
 };

--- a/src/routes/(site)/show/[show_number]/[slug]/transcript/+page.server.ts
+++ b/src/routes/(site)/show/[show_number]/[slug]/transcript/+page.server.ts
@@ -6,7 +6,7 @@ export const load: PageServerLoad = async function ({ setHeaders, params, locals
 	const { show } = await parent();
 	const cache_ms = get_show_cache_s(show.date);
 	setHeaders({
-		'cache-control': `public s-max-age=${cache_ms}, stale-while-revalidate=${cache_ms}`
+		'cache-control': `public s-maxage=${cache_ms}, stale-while-revalidate=${cache_ms}`
 	});
 	const { show_number } = params;
 

--- a/src/routes/(site)/sickpicks/+page.server.ts
+++ b/src/routes/(site)/sickpicks/+page.server.ts
@@ -72,7 +72,7 @@ export const load: PageServerLoad = async function ({ locals, setHeaders }) {
 
 	// Cache for 3 days, stale for 1 hour OK
 	setHeaders({
-		'cache-control': `public s-max-age=${60 * 60 * 24 * 3}, stale-while-revalidate=${60 * 60 * 1}`
+		'cache-control': `public s-maxage=${60 * 60 * 24 * 3}, stale-while-revalidate=${60 * 60 * 1}`
 	});
 
 	return {

--- a/src/routes/(site)/snackpack/+page.server.ts
+++ b/src/routes/(site)/snackpack/+page.server.ts
@@ -91,7 +91,7 @@ async function fetchBroadcastList() {
 export const load: PageServerLoad = async function ({ setHeaders, params, locals }) {
 	// 1 min cache with 1 min stale allowed
 	setHeaders({
-		'cache-control': `public s-max-age=60, stale-while-revalidate=60`
+		'cache-control': `public s-maxage=60, stale-while-revalidate=60`
 	});
 
 	const subs = await fetch(


### PR DESCRIPTION
Looks like its `max-age` for private cache. `s-maxage` for shared. 