### PR TITLE
Fix form data

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -108,17 +108,9 @@ export const document_policy: Handle = async function ({ event, resolve }) {
 const safe_paths = new Set(['/api/errors', '/api/57475/3v3n7']);
 export const safe_form_data: Handle = async function ({ event, resolve }) {
 	if (safe_paths.has(event.url.pathname)) return resolve(event);
-	const contentType = event.request.headers.get('content-type');
-	if (contentType?.includes('form-data')) {
-		try {
-			const result = await form_data({ event, resolve });
-			return result;
-		} catch (error) {
-			console.error('Error parsing form-data:');
-			console.error(error);
-		}
-	}
-	return resolve(event);
+
+	const result = await form_data({ event, resolve });
+	return result;
 };
 
 // * END HOOKS

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -108,9 +108,14 @@ export const document_policy: Handle = async function ({ event, resolve }) {
 const safe_paths = new Set(['/api/errors', '/api/57475/3v3n7']);
 export const safe_form_data: Handle = async function ({ event, resolve }) {
 	if (safe_paths.has(event.url.pathname)) return resolve(event);
-
-	const result = await form_data({ event, resolve });
-	return result;
+	try {
+		const result = await form_data({ event, resolve });
+		return result;
+	} catch (error) {
+		console.error('Error parsing form-data:');
+		console.error(error);
+	}
+	return resolve(event);
 };
 
 // * END HOOKS


### PR DESCRIPTION
fixes #1749

Not sure when or how but for some reason contentType no longer includes "form-data". I added actions checks in "sk-form-data": "^2.0.2" which now makes sure you are using a svelte action before attempting to parse form data.