### PR TITLE
fixes abort error from sharing

### DIFF
--- a/src/lib/share/HairButton.svelte
+++ b/src/lib/share/HairButton.svelte
@@ -1,20 +1,25 @@
 <script lang="ts">
 	// Why is this file called HairButton? https://github.com/syntaxfm/website/issues/1563
-	import { episode_share_status, player } from '$/state/player';
+	import { episode_share_status } from '$/state/player';
 	import type { Show } from '@prisma/client';
 	import Icon from '../Icon.svelte';
 	export let show: Show;
 
-	function share() {
+	async function share() {
 		const is_possibly_mobile =
 			/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 
 		if (is_possibly_mobile && navigator?.share) {
-			navigator.share({
-				url: `https://syntax.fm/show/${show.number}`,
-				text: 'Syntax podcast ' + show.title,
-				title: show.title
-			});
+			try {
+				await navigator.share({
+					url: `https://syntax.fm/show/${show.number}`,
+					text: 'Syntax podcast ' + show.title,
+					title: show.title
+				});
+			} catch (err) {
+				// This is here because navigator throws AbortError if the user cancels the share
+				return;
+			}
 		} else {
 			$episode_share_status = true;
 		}


### PR DESCRIPTION
Fixes #1751

Just wraps navigator in a try/catch because cancelling throws.
https://stackoverflow.com/questions/60510383/web-share-api-navigator-share-problem-when-canceling-share-dialog-ios-and-androi