### PR TITLE
simplify date parse from cache

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -20,7 +20,8 @@ export const redis =
 	cache_status == 'ONLINE'
 		? new Redis({
 				url: UPSPLASH_URL,
-				token: UPSPLASH_TOKEN
+				token: UPSPLASH_TOKEN,
+				automaticDeserialization: false
 			})
 		: null;
 console.log(`🤓 Cache Status... ${cache_status}`);

--- a/src/server/cache/cache_mang.ts
+++ b/src/server/cache/cache_mang.ts
@@ -1,16 +1,21 @@
-import { Prisma } from '@prisma/client';
+import { Prisma, type Show } from '@prisma/client';
 import { cache_status, redis } from '$/hooks.server';
 import { get_show_cache_s } from '../../utilities/get_show_cache_ms';
 import type { DMMF } from '@prisma/client/runtime/library';
 
 // Function to get DateTime field names from all Prisma models
 // This lets us know which date time fields need to be converted to JS Date objects from the cache without guessing.
-function get_all_date_time_fields(): Record<string, string[]> {
+function get_all_date_time_fields() {
 	const dmmf = Prisma.dmmf as DMMF.Document;
-	return dmmf.datamodel.models.reduce((acc: Record<string, string[]>, model) => {
-		acc[model.name] = model.fields.filter((f) => f.type === 'DateTime').map((f) => f.name);
-		return acc;
-	}, {});
+	const fields = new Set<string>();
+	dmmf.datamodel.models.forEach((model) => {
+		model.fields.filter((f) => {
+			if (f.type === 'DateTime') {
+				fields.add(f.name);
+			}
+		});
+	});
+	return fields;
 }
 
 const date_time_fields = get_all_date_time_fields();
@@ -23,40 +28,28 @@ export async function super_cache_mang<T>(
 		return db_call();
 	}
 
-	const cached_data = await redis.get<T>(cache_key).catch(() => null);
+	const cache_string = await redis.get<string>(cache_key).catch(() => null);
 
-	if (cached_data) {
-		return convert_dates(cached_data, Object.values(date_time_fields).flat());
+	if (cache_string) {
+		return JSON.parse(cache_string, (key, value) => {
+			if (date_time_fields.has(key)) {
+				return new Date(value);
+			}
+			return value;
+		}) as T;
 	}
 
 	const data = await db_call();
 
 	if (data) {
-		const is_show_item = cache_key.startsWith('show:');
-		const expiration_time =
-			is_show_item && !Array.isArray(data) ? get_show_cache_s((data as any).date) : 3600; // Default to 1 hour for lists and non-show models
+		let expiration_time = 3600; // Default to 1 hour for lists and non-show models
+		if (cache_key.startsWith('show:') && !Array.isArray(data)) {
+			const show = data as unknown as Show;
+			expiration_time = get_show_cache_s(show.date);
+		}
 		await redis.set(cache_key, data, { ex: expiration_time });
 	}
 
-	return data;
-}
-
-function convert_dates<T>(data: T, date_fields: string[]): T {
-	if (Array.isArray(data)) {
-		return data.map((item) => convert_dates(item, date_fields)) as T;
-	} else if (data !== null && typeof data === 'object') {
-		const converted_data: Record<string, any> = {};
-		for (const [key, value] of Object.entries(data)) {
-			if (date_fields.includes(key) && typeof value === 'string') {
-				converted_data[key] = new Date(value);
-			} else if (typeof value === 'object') {
-				converted_data[key] = convert_dates(value, date_fields);
-			} else {
-				converted_data[key] = value;
-			}
-		}
-		return converted_data as T;
-	}
 	return data;
 }
 


### PR DESCRIPTION
* This disables automaticDeserialization in the upstash client (the default is to just use JSON.parse)
* Calls JSON.parse manually when pulling from the cache
  * adds a reviver function to convert the dates during parse