### PR TITLE
refactor: :mag: move robots.txt to integrate the sitemap

### DIFF
--- a/src/routes/robots.txt/+server.ts
+++ b/src/routes/robots.txt/+server.ts
@@ -1,0 +1,18 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { PUBLIC_URL } from '$env/static/public';
+
+export const GET: RequestHandler = async function GET({ setHeaders }) {
+	const robotsTxt = `User-agent: *
+Disallow: /admin
+Disallow: /haters
+Disallow: /api
+
+Sitemap:  https://${PUBLIC_URL}/sitemap.xml`;
+
+	setHeaders({
+		'cache-control': 'max-age=0, s-maxage=3600',
+		'Content-Type': 'text/plain'
+	});
+
+	return new Response(robotsTxt);
+};

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Disallow: /admin
-Disallow: /haters
-Disallow: /api


### PR DESCRIPTION
Instead of manually submitting your sitemap to Google, Bing & other search engines in the future; you can reference it in the robots.txt file as outlined on [Google here](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap#addsitemap)  and [here](https://developers.google.com/search/docs/crawling-indexing/robots/robots_txt#sitemap)

As far as I know it's followed by all search engines crawler; here is another [Bing](https://www.bing.com/webmasters/help/Sitemaps-3b5cf6ed) documentation

Since I had to use the PUBLIC_URL variable I moved it from static folder to be server generated (with a long cache).