### PR TITLE
Update to npm-run-all2

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"js-cookie": "^3.0.5",
 		"linkedom": "^0.18.3",
 		"media-chrome": "^3.2.3",
-		"npm-run-all": "^4.1.5",
+		"npm-run-all2": "^6.2.2",
 		"openai": "^3.3.0",
 		"p-map": "^7.0.2",
 		"puppeteer-core": "^22.12.1",


### PR DESCRIPTION
[`npm-run-all2`](https://github.com/bcomnes/npm-run-all2) is a community fork of [`npm-run-all`](https://github.com/mysticatea/npm-run-all), which sadly hasn't had updates for over 5 years. 

I started the fork because I use `run-{p,s}` everywhere and wanted to see its ongoing maintenance continued. We're at 40k public repos adopting the fork so far, and are a designated replacement package in renovate bot. The plan for the fork is to keep maintaining the project pretty much as is for the foreseeable future. 

I'm sending out a few PRs to notable repos that I spot to see gauge interest on switching over.

It's a drop in replacement (same bin names) so this should be all you need to do to switch over. 

Love the podcast! Feel free to close if you aren't interested as well. 