### PR TITLE
fix: #1384 - player button press when playing

### DIFF
--- a/src/routes/(site)/show/[show_number]/[slug]/+layout.svelte
+++ b/src/routes/(site)/show/[show_number]/[slug]/+layout.svelte
@@ -34,12 +34,19 @@
 	}
 
 	function play_show() {
-		player.start_show(show, time_param_to_seconds(time_start));
+		if ($player.current_show?.number !== show.number || $player.status === 'INITIAL') {
+			player.start_show(show, time_param_to_seconds(time_start));
+		} else if ($player.status === 'PLAYING') {
+			player.pause();
+		} else {
+			player.play();
+		}
 	}
 
 	function variable_svg(node: HTMLElement) {
 		replace_color(node);
 	}
+	
 </script>
 
 <header>
@@ -82,7 +89,12 @@
 						? 'ing'
 						: ''}"
 				/>
-				Play{$player.current_show?.number === show.number ? 'ing' : ''} Episode {show.number}
+				{#if $player.status === 'PAUSED' && $player.current_show?.number === show.number}
+					Resume
+				{:else}
+					Play{$player.current_show?.number === show.number ? 'ing' : ''} 
+				{/if}
+				Episode {show.number}
 			</button>
 			<span>or</span>
 			<ListenLinks {show} />

--- a/src/state/player.ts
+++ b/src/state/player.ts
@@ -116,7 +116,7 @@ const new_player_state = () => {
 				state.audio.src = incoming_show.url;
 				state.audio.currentTime = resume_time;
 				state.current_show = incoming_show;
-				state.status = 'LOADED';
+				state.status = resume_time > 0 ? 'PAUSED' : 'LOADED';
 			}
 			return state;
 		});
@@ -179,6 +179,7 @@ const new_player_state = () => {
 				// Finally Start Playing
 				this.play();
 			} catch (error) {
+				console.log('setting initial...');
 				update((state) => ({ ...state, status: 'INITIAL' }));
 			}
 		},


### PR DESCRIPTION
* This is a partial fix for #1384  - I did not add anything to jump to the player, just improved the button functionality
* This fixes the player button on the show page
  * If the episode is already playing, pressing the play button will pause the episode
  * If the episode is paused, the button will say "resume"
  * If the site is freshly loaded to a show page that the user was last listening to, the button will say "resume"