### PR TITLE
removes locals.prisma

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,11 +1,11 @@
 // * Server Side Middleware
 // https://kit.svelte.dev/docs/hooks
 
-import { PrismaClient } from '@prisma/client';
 import * as Sentry from '@sentry/sveltekit';
 import { redirect, type Handle } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 import { form_data } from 'sk-form-data';
+import { prisma_client } from '$/server/prisma-client';
 import { find_user_by_access_token } from './server/auth/users';
 // import { dev } from '$app/environment';
 import { dev } from '$app/environment';
@@ -30,7 +30,6 @@ console.log(`🤓 Cache Status... ${cache_status}`);
 
 // * START UP
 // RUNS ONCE ON FILE LOAD
-export const prisma_client = new PrismaClient();
 
 Sentry.init({
 	release: `syntax@${__VER__}`,

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -81,7 +81,6 @@ export const admin: Handle = async function ({ event, resolve }) {
 export const prisma: Handle = async function ({ event, resolve }) {
 	const ip = event.request.headers.get('x-forwarded-for') as string;
 	const country = event.request.headers.get('x-vercel-ip-country') as string;
-	event.locals.prisma = prisma_client;
 	event.locals.session = {
 		...event.locals.session,
 		ip,

--- a/src/routes/(blank)/og/[show_number].jpg/+server.ts
+++ b/src/routes/(blank)/og/[show_number].jpg/+server.ts
@@ -1,7 +1,7 @@
 import { dev } from '$app/environment';
 import chrome from '@sparticuz/chromium';
 import puppeteer, { Browser, type Product } from 'puppeteer-core';
-import { redis } from '../../../../hooks.server.js';
+import { redis } from '$/hooks.server.js';
 const exePath = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 
 async function getOptions() {

--- a/src/routes/(blank)/og/[show_number_or_title]/+page.server.ts
+++ b/src/routes/(blank)/og/[show_number_or_title]/+page.server.ts
@@ -1,7 +1,8 @@
+import { prisma_client } from '$/hooks.server';
 import { SHOW_QUERY } from '$server/ai/queries.js';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async function ({ setHeaders, params, locals }) {
+export const load: PageServerLoad = async function ({ setHeaders, params }) {
 	setHeaders({
 		'cache-control': 'max-age=240'
 	});
@@ -22,7 +23,7 @@ export const load: PageServerLoad = async function ({ setHeaders, params, locals
 	// If its a Show, we need to return the show from the DB
 	const { include } = SHOW_QUERY();
 	return {
-		show: await locals.prisma.show.findUnique({
+		show: await prisma_client.show.findUnique({
 			where: {
 				number: show_number
 			},

--- a/src/routes/(blank)/og/[show_number_or_title]/+page.server.ts
+++ b/src/routes/(blank)/og/[show_number_or_title]/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import { SHOW_QUERY } from '$server/ai/queries.js';
 import type { PageServerLoad } from './$types';
 

--- a/src/routes/(site)/+page.server.ts
+++ b/src/routes/(site)/+page.server.ts
@@ -1,5 +1,6 @@
 import type { Actions } from '@sveltejs/kit';
-import { prisma_client, redis } from '../../hooks.server';
+import { redis } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ url }) => {

--- a/src/routes/(site)/+page.server.ts
+++ b/src/routes/(site)/+page.server.ts
@@ -1,5 +1,5 @@
 import type { Actions } from '@sveltejs/kit';
-import { redis } from '../../hooks.server';
+import { prisma_client, redis } from '../../hooks.server';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ url }) => {
@@ -12,8 +12,8 @@ export const load: PageServerLoad = async ({ url }) => {
 };
 
 export const actions: Actions = {
-	logout: async function logout({ locals, cookies }) {
-		await locals.prisma.session.delete({
+	logout: async function logout({ cookies }) {
+		await prisma_client.session.delete({
 			where: {
 				access_token: cookies.get('access_token')
 			}

--- a/src/routes/(site)/admin/+page.server.ts
+++ b/src/routes/(site)/admin/+page.server.ts
@@ -1,5 +1,7 @@
-export const load = async (event) => {
-	const next_shows = await event.locals.prisma.show.findMany({
+import { prisma_client } from '$/hooks.server';
+
+export const load = async () => {
+	const next_shows = await prisma_client.show.findMany({
 		where: {
 			date: {
 				gt: new Date()
@@ -8,7 +10,7 @@ export const load = async (event) => {
 		include: {
 			aiShowNote: {
 				include: {
-					topics: true,
+					topics: true
 				}
 			}
 		},
@@ -17,7 +19,7 @@ export const load = async (event) => {
 		},
 		take: 9
 	});
-	const last_9_shows = await event.locals.prisma.show.findMany({
+	const last_9_shows = await prisma_client.show.findMany({
 		where: {
 			date: {
 				lt: new Date()
@@ -26,7 +28,7 @@ export const load = async (event) => {
 		include: {
 			aiShowNote: {
 				include: {
-					topics: true,
+					topics: true
 				}
 			}
 		},

--- a/src/routes/(site)/admin/+page.server.ts
+++ b/src/routes/(site)/admin/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const load = async () => {
 	const next_shows = await prisma_client.show.findMany({

--- a/src/routes/(site)/admin/cache/+page.server.ts
+++ b/src/routes/(site)/admin/cache/+page.server.ts
@@ -1,4 +1,4 @@
-import { cache_status, redis } from '../../../../hooks.server';
+import { cache_status, redis } from '$/hooks.server';
 
 export const load = async () => {
 	return {

--- a/src/routes/(site)/admin/shows/+page.server.ts
+++ b/src/routes/(site)/admin/shows/+page.server.ts
@@ -3,7 +3,7 @@ import { error } from '@sveltejs/kit';
 import { get_transcript } from '$server/transcripts/deepgram';
 import { aiNoteRequestHandler } from '$server/ai/requestHandlers';
 import type { PageServerLoad } from './$types';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const config = {
 	maxDuration: 300 // vercel timeout

--- a/src/routes/(site)/admin/shows/+page.server.ts
+++ b/src/routes/(site)/admin/shows/+page.server.ts
@@ -3,14 +3,15 @@ import { error } from '@sveltejs/kit';
 import { get_transcript } from '$server/transcripts/deepgram';
 import { aiNoteRequestHandler } from '$server/ai/requestHandlers';
 import type { PageServerLoad } from './$types';
+import { prisma_client } from '$/hooks.server';
 
 export const config = {
 	maxDuration: 300 // vercel timeout
 };
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async () => {
 	return {
-		shows: await locals.prisma.show.findMany({
+		shows: await prisma_client.show.findMany({
 			orderBy: { number: 'desc' },
 			include: {
 				aiShowNote: {
@@ -43,25 +44,25 @@ export const actions = {
 		return import_or_update_all_shows();
 	},
 
-	delete_all_shows: async ({ locals }) => {
+	delete_all_shows: async () => {
 		// Order of these is important because of how db relations work
-		await locals.prisma.showGuest.deleteMany({});
-		await locals.prisma.transcriptUtteranceWord.deleteMany({});
-		await locals.prisma.transcriptUtterance.deleteMany({});
-		await locals.prisma.transcript.deleteMany({});
-		await locals.prisma.aiShowNote.deleteMany({});
-		await locals.prisma.show.deleteMany({});
-		await locals.prisma.socialLink.deleteMany({});
-		await locals.prisma.guest.deleteMany({});
+		await prisma_client.showGuest.deleteMany({});
+		await prisma_client.transcriptUtteranceWord.deleteMany({});
+		await prisma_client.transcriptUtterance.deleteMany({});
+		await prisma_client.transcript.deleteMany({});
+		await prisma_client.aiShowNote.deleteMany({});
+		await prisma_client.show.deleteMany({});
+		await prisma_client.socialLink.deleteMany({});
+		await prisma_client.guest.deleteMany({});
 		return { message: 'Delete All Shows' };
 	},
-	delete_transcript: async ({ locals, request }) => {
+	delete_transcript: async ({ request }) => {
 		const data = await request.formData();
 		const show_number = parseInt(data.get('show_number')?.toString() || '');
 		if (!show_number) {
 			error(400, 'Invalid Show Number');
 		}
-		await locals.prisma.transcript.delete({
+		await prisma_client.transcript.delete({
 			where: {
 				show_number
 			}

--- a/src/routes/(site)/admin/shows/[show_number]/+page.server.ts
+++ b/src/routes/(site)/admin/shows/[show_number]/+page.server.ts
@@ -3,7 +3,7 @@ import type { PageServerLoad } from './$types';
 import type { Actions } from './$types';
 import { fail } from '@sveltejs/kit';
 import { cache } from '$/server/cache/cache';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 type AiShowNoteUpdate = Pick<AiShowNote, 'title' | 'description'>;
 

--- a/src/routes/(site)/admin/shows/[show_number]/+page.server.ts
+++ b/src/routes/(site)/admin/shows/[show_number]/+page.server.ts
@@ -3,6 +3,7 @@ import type { PageServerLoad } from './$types';
 import type { Actions } from './$types';
 import { fail } from '@sveltejs/kit';
 import { cache } from '$/server/cache/cache';
+import { prisma_client } from '$/hooks.server';
 
 type AiShowNoteUpdate = Pick<AiShowNote, 'title' | 'description'>;
 
@@ -17,7 +18,7 @@ export const actions = {
 		}
 
 		const show_number = parseInt(params.show_number);
-		await locals.prisma.aiShowNote.update({
+		await prisma_client.aiShowNote.update({
 			where: {
 				show_number
 			},
@@ -33,9 +34,9 @@ export const actions = {
 	}
 } satisfies Actions;
 
-export const load: PageServerLoad = async ({ locals, params }) => {
+export const load: PageServerLoad = async ({ params }) => {
 	return {
-		show: await locals.prisma.show.findUnique({
+		show: await prisma_client.show.findUnique({
 			where: {
 				number: parseInt(params.show_number)
 			},

--- a/src/routes/(site)/admin/transcripts/+page.server.ts
+++ b/src/routes/(site)/admin/transcripts/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import { import_transcripts } from '$server/transcripts/transcripts';
 import type { Actions, PageServerLoad } from './$types';
 

--- a/src/routes/(site)/admin/transcripts/+page.server.ts
+++ b/src/routes/(site)/admin/transcripts/+page.server.ts
@@ -1,9 +1,10 @@
+import { prisma_client } from '$/hooks.server';
 import { import_transcripts } from '$server/transcripts/transcripts';
 import type { Actions, PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async () => {
 	return {
-		transcripts: await locals.prisma.transcript.findMany({
+		transcripts: await prisma_client.transcript.findMany({
 			include: {
 				show: true,
 				_count: {
@@ -29,9 +30,9 @@ export const actions: Actions = {
 		});
 	},
 
-	delete_all_transcripts: async ({ locals }) => {
+	delete_all_transcripts: async () => {
 		// Order of these is important because of how db relations work
-		await locals.prisma.transcript.deleteMany({});
+		await prisma_client.transcript.deleteMany({});
 		return { message: 'Deleted All Transcripts!' };
 	}
 };

--- a/src/routes/(site)/admin/videos/+page.server.ts
+++ b/src/routes/(site)/admin/videos/+page.server.ts
@@ -1,5 +1,7 @@
-export const load = async ({ locals }) => {
-	const local_playlists = await locals.prisma.playlist.findMany({
+import { prisma_client } from '$/hooks.server';
+
+export const load = async () => {
+	const local_playlists = await prisma_client.playlist.findMany({
 		orderBy: {
 			created_at: 'desc'
 		},

--- a/src/routes/(site)/admin/videos/+page.server.ts
+++ b/src/routes/(site)/admin/videos/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const load = async () => {
 	const local_playlists = await prisma_client.playlist.findMany({

--- a/src/routes/(site)/admin/videos/[playlist_id]/+page.server.ts
+++ b/src/routes/(site)/admin/videos/[playlist_id]/+page.server.ts
@@ -1,9 +1,11 @@
-export const load = async ({ params, locals }) => {
+import { prisma_client } from '$/hooks.server';
+
+export const load = async ({ params }) => {
 	const { playlist_id } = params;
 
 	try {
 		// Fetch the playlist details
-		const playlist = await locals.prisma.playlist.findUnique({
+		const playlist = await prisma_client.playlist.findUnique({
 			where: { id: playlist_id },
 			include: {
 				videos: {

--- a/src/routes/(site)/admin/videos/[playlist_id]/+page.server.ts
+++ b/src/routes/(site)/admin/videos/[playlist_id]/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const load = async ({ params }) => {
 	const { playlist_id } = params;

--- a/src/routes/(site)/admin/videos/import/+page.server.ts
+++ b/src/routes/(site)/admin/videos/import/+page.server.ts
@@ -1,13 +1,14 @@
+import { prisma_client } from '$/hooks.server';
 import { get_remote_playlists, import_playlist } from '$/server/video/youtube_api';
 import { fail } from '@sveltejs/kit';
 
-export const load = async ({ locals }) => {
-	const playlists = await locals.prisma.remotePlaylist.findMany({
+export const load = async () => {
+	const playlists = await prisma_client.remotePlaylist.findMany({
 		orderBy: {
 			created_at: 'desc'
 		}
 	});
-	const local_playlists = await locals.prisma.playlist.findMany({
+	const local_playlists = await prisma_client.playlist.findMany({
 		orderBy: {
 			created_at: 'desc'
 		},

--- a/src/routes/(site)/admin/videos/import/+page.server.ts
+++ b/src/routes/(site)/admin/videos/import/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import { get_remote_playlists, import_playlist } from '$/server/video/youtube_api';
 import { fail } from '@sveltejs/kit';
 

--- a/src/routes/(site)/guest/[name_slug]/+page.server.ts
+++ b/src/routes/(site)/guest/[name_slug]/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import { get_show_card_query } from '$/server/shows/shows_queries';
 
 export const load = async function ({ params }) {

--- a/src/routes/(site)/guests/+page.server.ts
+++ b/src/routes/(site)/guests/+page.server.ts
@@ -1,5 +1,7 @@
-export const load = async function ({ locals, params }) {
-	const guests = await locals.prisma.guest.findMany({
+import { prisma_client } from '$/hooks.server';
+
+export const load = async function () {
+	const guests = await prisma_client.guest.findMany({
 		include: {
 			shows: {
 				select: {

--- a/src/routes/(site)/guests/+page.server.ts
+++ b/src/routes/(site)/guests/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const load = async function () {
 	const guests = await prisma_client.guest.findMany({

--- a/src/routes/(site)/show/[show_number]/[slug]/+layout.server.ts
+++ b/src/routes/(site)/show/[show_number]/[slug]/+layout.server.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { processor } from '$/utilities/markdown.js';
 import { cache } from '$/server/cache/cache';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const load = async function ({ params, locals, url }) {
 	const show_number = parseInt(params.show_number);

--- a/src/routes/(site)/show/[show_number]/[slug]/+layout.server.ts
+++ b/src/routes/(site)/show/[show_number]/[slug]/+layout.server.ts
@@ -1,6 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { processor } from '$/utilities/markdown.js';
 import { cache } from '$/server/cache/cache';
+import { prisma_client } from '$/hooks.server';
 
 export const load = async function ({ params, locals, url }) {
 	const show_number = parseInt(params.show_number);
@@ -8,7 +9,7 @@ export const load = async function ({ params, locals, url }) {
 	// Caches and gets show dynamically based on release date
 	const show_promise = cache.shows.show(show_number);
 
-	const prev_next_show_promise = locals.prisma.show.findMany({
+	const prev_next_show_promise = prisma_client.show.findMany({
 		where: {
 			number: {
 				in: [show_number - 1, show_number + 1]

--- a/src/routes/(site)/show/[show_number]/[slug]/transcript/+page.server.ts
+++ b/src/routes/(site)/show/[show_number]/[slug]/transcript/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import { transcript_with_utterances } from '$server/ai/queries';
 import { get_show_cache_s } from '$utilities/get_show_cache_ms';
 import type { PageServerLoad } from './$types';

--- a/src/routes/(site)/show/[show_number]/[slug]/transcript/+page.server.ts
+++ b/src/routes/(site)/show/[show_number]/[slug]/transcript/+page.server.ts
@@ -1,8 +1,9 @@
+import { prisma_client } from '$/hooks.server';
 import { transcript_with_utterances } from '$server/ai/queries';
 import { get_show_cache_s } from '$utilities/get_show_cache_ms';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async function ({ setHeaders, params, locals, parent, url }) {
+export const load: PageServerLoad = async function ({ setHeaders, params, parent }) {
 	const { show } = await parent();
 	const cache_ms = get_show_cache_s(show.date);
 	setHeaders({
@@ -11,7 +12,7 @@ export const load: PageServerLoad = async function ({ setHeaders, params, locals
 	const { show_number } = params;
 
 	return {
-		transcript: await locals.prisma.transcript.findUnique({
+		transcript: await prisma_client.transcript.findUnique({
 			where: { show_number: parseInt(show_number) },
 			...transcript_with_utterances
 		})

--- a/src/routes/(site)/sickpicks/+page.server.ts
+++ b/src/routes/(site)/sickpicks/+page.server.ts
@@ -1,6 +1,6 @@
 import type { PageServerLoad } from './$types';
 import { processor } from '$/utilities/markdown';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 function cleanUpLines(string: string) {
 	return string

--- a/src/routes/(site)/sickpicks/+page.server.ts
+++ b/src/routes/(site)/sickpicks/+page.server.ts
@@ -1,5 +1,6 @@
 import type { PageServerLoad } from './$types';
 import { processor } from '$/utilities/markdown';
+import { prisma_client } from '$/hooks.server';
 
 function cleanUpLines(string: string) {
 	return string
@@ -10,9 +11,9 @@ function cleanUpLines(string: string) {
 		.join('\n');
 }
 
-export const load: PageServerLoad = async function ({ locals, setHeaders }) {
+export const load: PageServerLoad = async function ({ setHeaders }) {
 	// Load ALL shows from the database
-	const shows = await locals.prisma.show.findMany({
+	const shows = await prisma_client.show.findMany({
 		select: {
 			show_type: true,
 			number: true,

--- a/src/routes/(site)/videos/+page.server.ts
+++ b/src/routes/(site)/videos/+page.server.ts
@@ -1,5 +1,7 @@
-export const load = async function ({ locals }) {
-	const playlists = await locals.prisma.playlist.findMany({
+import { prisma_client } from '$/hooks.server';
+
+export const load = async function () {
+	const playlists = await prisma_client.playlist.findMany({
 		orderBy: {
 			created_at: 'desc'
 		},

--- a/src/routes/(site)/videos/+page.server.ts
+++ b/src/routes/(site)/videos/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const load = async function () {
 	const playlists = await prisma_client.playlist.findMany({

--- a/src/routes/(site)/videos/[p_slug]/+page.server.ts
+++ b/src/routes/(site)/videos/[p_slug]/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const load = async function ({ params }) {
 	const { p_slug } = params;

--- a/src/routes/(site)/videos/[p_slug]/+page.server.ts
+++ b/src/routes/(site)/videos/[p_slug]/+page.server.ts
@@ -1,6 +1,8 @@
-export const load = async function ({ locals, params }) {
+import { prisma_client } from '$/hooks.server';
+
+export const load = async function ({ params }) {
 	const { p_slug } = params;
-	const playlist = await locals.prisma.playlist.findUnique({
+	const playlist = await prisma_client.playlist.findUnique({
 		where: { slug: p_slug },
 		include: {
 			videos: {

--- a/src/routes/(site)/videos/[p_slug]/[v_slug]/+page.server.ts
+++ b/src/routes/(site)/videos/[p_slug]/[v_slug]/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import { get_show_card_query } from '$/server/shows/shows_queries';
 import { get_first_paragraph } from '$/utilities/get_first_paragraph';
 import { processor } from '$/utilities/markdown.js';

--- a/src/routes/api/oauth/github/+server.ts
+++ b/src/routes/api/oauth/github/+server.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import { GITHUB_AUTH_URL } from '$const';
 import { PUBLIC_GITHUB_ID } from '$env/static/public';
 import type { RequestHandler } from '@sveltejs/kit';
+import { prisma_client } from '$/hooks.server';
 
 export const GET: RequestHandler = async function ({ locals, cookies }) {
 	const access_token = cookies.get('access_token');
@@ -12,7 +13,7 @@ export const GET: RequestHandler = async function ({ locals, cookies }) {
 
 		try {
 			// Create a session with the session token to verify the user later
-			await locals.prisma.session.create({
+			await prisma_client.session.create({
 				data: {
 					session_token,
 					ip: locals.session.ip,

--- a/src/routes/api/oauth/github/+server.ts
+++ b/src/routes/api/oauth/github/+server.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import { GITHUB_AUTH_URL } from '$const';
 import { PUBLIC_GITHUB_ID } from '$env/static/public';
 import type { RequestHandler } from '@sveltejs/kit';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const GET: RequestHandler = async function ({ locals, cookies }) {
 	const access_token = cookies.get('access_token');

--- a/src/routes/api/seed.json/content.server.ts
+++ b/src/routes/api/seed.json/content.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export async function content() {
 	// Last 20 Shows

--- a/src/routes/api/shows/+server.ts
+++ b/src/routes/api/shows/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import { format } from 'date-fns';
 import { shows_api_query } from './query.js';
-import { prisma_client } from '$/hooks.server.js';
+import { prisma_client } from '$/server/prisma-client';
 
 export async function GET() {
 	const data = await prisma_client.show.findMany(shows_api_query());

--- a/src/routes/api/shows/+server.ts
+++ b/src/routes/api/shows/+server.ts
@@ -1,9 +1,10 @@
 import { json } from '@sveltejs/kit';
 import { format } from 'date-fns';
 import { shows_api_query } from './query.js';
+import { prisma_client } from '$/hooks.server.js';
 
-export async function GET({ locals }) {
-	const data = await locals.prisma.show.findMany(shows_api_query());
+export async function GET() {
+	const data = await prisma_client.show.findMany(shows_api_query());
 
 	const shows = data.map((show) => {
 		return {

--- a/src/routes/api/shows/[number=show_number]/+server.ts
+++ b/src/routes/api/shows/[number=show_number]/+server.ts
@@ -1,12 +1,13 @@
 import { error, json } from '@sveltejs/kit';
 import { format } from 'date-fns';
 import { shows_api_query } from '../query.js';
+import { prisma_client } from '$/hooks.server.js';
 
 const query = shows_api_query();
 
-export async function GET({ locals, params }) {
+export async function GET({ params }) {
 	const show_number = parseInt(params.number);
-	const data = await locals.prisma.show.findFirst({
+	const data = await prisma_client.show.findFirst({
 		where: {
 			AND: [
 				{ number: show_number },

--- a/src/routes/api/shows/[number=show_number]/+server.ts
+++ b/src/routes/api/shows/[number=show_number]/+server.ts
@@ -1,7 +1,7 @@
 import { error, json } from '@sveltejs/kit';
 import { format } from 'date-fns';
 import { shows_api_query } from '../query.js';
-import { prisma_client } from '$/hooks.server.js';
+import { prisma_client } from '$/server/prisma-client';
 
 const query = shows_api_query();
 

--- a/src/routes/api/shows/latest/+server.ts
+++ b/src/routes/api/shows/latest/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import { format } from 'date-fns';
 import { shows_api_query } from '../query.js';
-import { prisma_client } from '$/hooks.server.js';
+import { prisma_client } from '$/server/prisma-client';
 
 export async function GET() {
 	const data = await prisma_client.show.findFirst(shows_api_query());

--- a/src/routes/api/shows/latest/+server.ts
+++ b/src/routes/api/shows/latest/+server.ts
@@ -1,9 +1,10 @@
 import { json } from '@sveltejs/kit';
 import { format } from 'date-fns';
 import { shows_api_query } from '../query.js';
+import { prisma_client } from '$/hooks.server.js';
 
-export async function GET({ locals }) {
-	const data = await locals.prisma.show.findFirst(shows_api_query());
+export async function GET() {
+	const data = await prisma_client.show.findFirst(shows_api_query());
 	if (data)
 		return json(
 			{

--- a/src/routes/content.json/content.server.ts
+++ b/src/routes/content.json/content.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '../../hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import type { Show } from '@prisma/client';
 
 interface Block {

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { PUBLIC_URL } from '$env/static/public';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 const site = `https://${PUBLIC_URL}`;
 

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,19 +1,20 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { PUBLIC_URL } from '$env/static/public';
+import { prisma_client } from '$/hooks.server';
 
 const site = `https://${PUBLIC_URL}`;
 
-export const GET: RequestHandler = async function GET({ setHeaders, locals }) {
-	const shows = await locals.prisma.show.findMany({
+export const GET: RequestHandler = async function GET({ setHeaders }) {
+	const shows = await prisma_client.show.findMany({
 		where: {
 			date: {
 				lte: new Date() // only shows in the future
 			}
 		}
 	});
-	const guests = await locals.prisma.guest.findMany();
-	const playlists = await locals.prisma.playlist.findMany();
-	const videos = await locals.prisma.video.findMany({
+	const guests = await prisma_client.guest.findMany();
+	const playlists = await prisma_client.playlist.findMany();
+	const videos = await prisma_client.video.findMany({
 		include: {
 			playlists: {
 				include: {

--- a/src/routes/webhooks/ai/+server.ts
+++ b/src/routes/webhooks/ai/+server.ts
@@ -4,7 +4,7 @@ import { transcript_without_ai_notes_query } from '$server/ai/queries';
 import { error, json } from '@sveltejs/kit';
 import { has_auth } from '../transcripts/has_auth';
 import type { RequestEvent } from './$types';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const config = {
 	maxDuration: 300 // vercel timeout

--- a/src/routes/webhooks/ai/+server.ts
+++ b/src/routes/webhooks/ai/+server.ts
@@ -1,16 +1,16 @@
 import { save_ai_notes_to_db } from '$server/ai/db';
 import { generate_ai_notes } from '$server/ai/openai';
-import { transcript_with_utterances, transcript_without_ai_notes_query } from '$server/ai/queries';
+import { transcript_without_ai_notes_query } from '$server/ai/queries';
 import { error, json } from '@sveltejs/kit';
 import { has_auth } from '../transcripts/has_auth';
 import type { RequestEvent } from './$types';
-import { Prisma } from '@prisma/client';
+import { prisma_client } from '$/hooks.server';
 
 export const config = {
 	maxDuration: 300 // vercel timeout
 };
 
-export const GET = async function transcriptCronHandler({ request, locals }: RequestEvent) {
+export const GET = async function transcriptCronHandler({ request }: RequestEvent) {
 	const start = Date.now();
 	const allowed = has_auth(request);
 	// 1. Make sure we have an API key
@@ -18,7 +18,7 @@ export const GET = async function transcriptCronHandler({ request, locals }: Req
 		error(401, 'Get outta here - Wrong Cron key or auth header');
 	}
 	// 2. Get the latest show without a transcript
-	const show = await locals.prisma.show.findFirst(transcript_without_ai_notes_query);
+	const show = await prisma_client.show.findFirst(transcript_without_ai_notes_query);
 
 	if (!show) {
 		return json({ message: 'No shows without AI Show notes found.' });

--- a/src/routes/webhooks/transcripts/+server.ts
+++ b/src/routes/webhooks/transcripts/+server.ts
@@ -2,7 +2,7 @@ import { error, json } from '@sveltejs/kit';
 import type { RequestEvent } from './$types';
 import { get_transcript } from '$server/transcripts/deepgram';
 import { has_auth } from './has_auth';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const config = {
 	maxDuration: 300 // vercel timeout

--- a/src/routes/webhooks/transcripts/+server.ts
+++ b/src/routes/webhooks/transcripts/+server.ts
@@ -2,12 +2,13 @@ import { error, json } from '@sveltejs/kit';
 import type { RequestEvent } from './$types';
 import { get_transcript } from '$server/transcripts/deepgram';
 import { has_auth } from './has_auth';
+import { prisma_client } from '$/hooks.server';
 
 export const config = {
 	maxDuration: 300 // vercel timeout
 };
 
-export const GET = async function transcriptCronHandler({ request, locals }: RequestEvent) {
+export const GET = async function transcriptCronHandler({ request }: RequestEvent) {
 	const start = Date.now();
 	const allowed = has_auth(request);
 	// 1. Make sure we have an API key
@@ -16,7 +17,7 @@ export const GET = async function transcriptCronHandler({ request, locals }: Req
 		error(401, 'Get outta here - Wrong Cron key or auth header');
 	}
 	// 2. Get the latest show without a transcript
-	const show = await locals.prisma.show.findFirst({
+	const show = await prisma_client.show.findFirst({
 		where: {
 			AND: [{ transcript: null }, { number: { gt: 700 } }]
 		},

--- a/src/server/ai/db.ts
+++ b/src/server/ai/db.ts
@@ -1,5 +1,5 @@
 import { generate_ai_notes } from './openai';
-import { prisma_client } from '../../hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 type Show = { number: number };
 type Result = Awaited<ReturnType<typeof generate_ai_notes>>;

--- a/src/server/ai/requestHandlers.ts
+++ b/src/server/ai/requestHandlers.ts
@@ -2,7 +2,7 @@ import { error, type RequestEvent } from '@sveltejs/kit';
 import { transcript_with_utterances } from './queries';
 import { generate_ai_notes } from './openai';
 import { save_ai_notes_to_db } from './db';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export async function aiNoteRequestHandler({ request }: RequestEvent) {
 	const data = await request.formData();

--- a/src/server/ai/requestHandlers.ts
+++ b/src/server/ai/requestHandlers.ts
@@ -1,13 +1,10 @@
-// TODO WES BOS Remove
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 import { error, type RequestEvent } from '@sveltejs/kit';
 import { transcript_with_utterances } from './queries';
 import { generate_ai_notes } from './openai';
 import { save_ai_notes_to_db } from './db';
+import { prisma_client } from '$/hooks.server';
 
-export async function aiNoteRequestHandler({ request, locals }: RequestEvent) {
+export async function aiNoteRequestHandler({ request }: RequestEvent) {
 	const data = await request.formData();
 	const show_number = parseInt(data.get('show_number')?.toString() || '');
 
@@ -15,7 +12,7 @@ export async function aiNoteRequestHandler({ request, locals }: RequestEvent) {
 		error(400, 'Invalid Show Number');
 	}
 
-	const show = await locals.prisma.show.findUnique({
+	const show = await prisma_client.show.findUnique({
 		where: { number: show_number },
 		include: {
 			transcript: transcript_with_utterances
@@ -26,7 +23,7 @@ export async function aiNoteRequestHandler({ request, locals }: RequestEvent) {
 		error(400, 'No show, or no transcript for this show');
 	}
 	// delete any existing ai notes
-	await locals.prisma.aiShowNote.deleteMany({
+	await prisma_client.aiShowNote.deleteMany({
 		where: {
 			show: {
 				number: show_number

--- a/src/server/auth/sessions.ts
+++ b/src/server/auth/sessions.ts
@@ -1,5 +1,5 @@
 import type { Session, User } from '@prisma/client';
-import { prisma_client } from '../../hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export async function find_session(
 	access_token: string,

--- a/src/server/auth/users.ts
+++ b/src/server/auth/users.ts
@@ -1,6 +1,6 @@
 import type { GithubUser } from '$const';
 import { add_user_to_role } from '../roles';
-import { prisma_client } from '../../hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import type { User } from '@prisma/client';
 
 export interface UserWithRoles extends User {

--- a/src/server/prisma-client.ts
+++ b/src/server/prisma-client.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prisma_client = new PrismaClient();

--- a/src/server/roles.ts
+++ b/src/server/roles.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '../hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export async function add_user_to_role(userId: string, roleName: string) {
 	// Find the role by its name

--- a/src/server/shows.ts
+++ b/src/server/shows.ts
@@ -5,7 +5,7 @@ import { left_pad } from '$utilities/left_pad';
 import { error } from '@sveltejs/kit';
 import matter from 'gray-matter';
 import slug from 'speakingurl';
-import { prisma_client as prisma, redis } from '../hooks.server';
+import { prisma_client as prisma } from '$/server/prisma-client';
 import { cache } from './cache/cache';
 
 interface FrontMatterGuest {

--- a/src/server/shows/shows.ts
+++ b/src/server/shows/shows.ts
@@ -1,5 +1,6 @@
 import { get_show_detail_query, get_last_10_shows_query, get_list_shows } from './shows_queries';
-import { prisma_client, redis } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
+import { redis } from '$/hooks.server';
 import { delete_keys_by_prefix, super_cache_mang } from '../cache/cache_mang';
 
 export async function show(show_number: number) {

--- a/src/server/transcripts/deepgram.ts
+++ b/src/server/transcripts/deepgram.ts
@@ -3,7 +3,7 @@
 // @ts-nocheck
 import DeepgramPkg from '@deepgram/sdk';
 const { Deepgram } = DeepgramPkg;
-import { prisma_client as prisma } from '../../hooks.server';
+import { prisma_client as prisma } from '$/server/prisma-client';
 import { error } from '@sveltejs/kit';
 import { keywords } from './fixes';
 import { addFlaggerAudio } from './flagger';

--- a/src/server/transcripts/transcripts.ts
+++ b/src/server/transcripts/transcripts.ts
@@ -3,7 +3,7 @@ import type { Show } from '@prisma/client';
 import { error } from '@sveltejs/kit';
 import fs, { readFile } from 'fs/promises';
 import path from 'path';
-import { prisma_client as prisma } from '../../hooks.server';
+import { prisma_client as prisma } from '$/server/prisma-client';
 import { detectSpeakerNames, getSlimUtterances } from './utils';
 import pMap from 'p-map';
 const transcripts_path = path.join(process.cwd(), 'src/assets/transcripts-flagged');

--- a/src/server/video/youtube_api.ts
+++ b/src/server/video/youtube_api.ts
@@ -1,5 +1,5 @@
 import { YOUTUBE_CHANNEL_ID } from '$/const';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import { YOUTUBE_API_KEY } from '$env/static/private';
 import slug from 'speakingurl';
 


### PR DESCRIPTION
Fixes #1755

It made no sense to have two ways to do the same thing. No need to use locals when an import will do.