### PR TITLE
move prisma client to own module

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,11 +1,11 @@
 // * Server Side Middleware
 // https://kit.svelte.dev/docs/hooks
 
-import { PrismaClient } from '@prisma/client';
 import * as Sentry from '@sentry/sveltekit';
 import { redirect, type Handle } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 import { form_data } from 'sk-form-data';
+import { prisma_client } from '$/server/prisma-client';
 import { find_user_by_access_token } from './server/auth/users';
 // import { dev } from '$app/environment';
 import { dev } from '$app/environment';
@@ -30,7 +30,6 @@ console.log(`🤓 Cache Status... ${cache_status}`);
 
 // * START UP
 // RUNS ONCE ON FILE LOAD
-export const prisma_client = new PrismaClient();
 
 Sentry.init({
 	release: `syntax@${__VER__}`,

--- a/src/routes/(blank)/og/[show_number].jpg/+server.ts
+++ b/src/routes/(blank)/og/[show_number].jpg/+server.ts
@@ -1,7 +1,7 @@
 import { dev } from '$app/environment';
 import chrome from '@sparticuz/chromium';
 import puppeteer, { Browser, type Product } from 'puppeteer-core';
-import { redis } from '../../../../hooks.server.js';
+import { redis } from '$/hooks.server.js';
 const exePath = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 
 async function getOptions() {

--- a/src/routes/(blank)/og/[show_number_or_title]/+page.server.ts
+++ b/src/routes/(blank)/og/[show_number_or_title]/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import { SHOW_QUERY } from '$server/ai/queries.js';
 import type { PageServerLoad } from './$types';
 

--- a/src/routes/(site)/+page.server.ts
+++ b/src/routes/(site)/+page.server.ts
@@ -1,5 +1,6 @@
 import type { Actions } from '@sveltejs/kit';
-import { prisma_client, redis } from '../../hooks.server';
+import { redis } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ url }) => {

--- a/src/routes/(site)/admin/+page.server.ts
+++ b/src/routes/(site)/admin/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const load = async () => {
 	const next_shows = await prisma_client.show.findMany({

--- a/src/routes/(site)/admin/cache/+page.server.ts
+++ b/src/routes/(site)/admin/cache/+page.server.ts
@@ -1,4 +1,4 @@
-import { cache_status, redis } from '../../../../hooks.server';
+import { cache_status, redis } from '$/hooks.server';
 
 export const load = async () => {
 	return {

--- a/src/routes/(site)/admin/shows/+page.server.ts
+++ b/src/routes/(site)/admin/shows/+page.server.ts
@@ -3,7 +3,7 @@ import { error } from '@sveltejs/kit';
 import { get_transcript } from '$server/transcripts/deepgram';
 import { aiNoteRequestHandler } from '$server/ai/requestHandlers';
 import type { PageServerLoad } from './$types';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const config = {
 	maxDuration: 300 // vercel timeout

--- a/src/routes/(site)/admin/shows/[show_number]/+page.server.ts
+++ b/src/routes/(site)/admin/shows/[show_number]/+page.server.ts
@@ -3,7 +3,7 @@ import type { PageServerLoad } from './$types';
 import type { Actions } from './$types';
 import { fail } from '@sveltejs/kit';
 import { cache } from '$/server/cache/cache';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 type AiShowNoteUpdate = Pick<AiShowNote, 'title' | 'description'>;
 

--- a/src/routes/(site)/admin/transcripts/+page.server.ts
+++ b/src/routes/(site)/admin/transcripts/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import { import_transcripts } from '$server/transcripts/transcripts';
 import type { Actions, PageServerLoad } from './$types';
 

--- a/src/routes/(site)/admin/videos/+page.server.ts
+++ b/src/routes/(site)/admin/videos/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const load = async () => {
 	const local_playlists = await prisma_client.playlist.findMany({

--- a/src/routes/(site)/admin/videos/[playlist_id]/+page.server.ts
+++ b/src/routes/(site)/admin/videos/[playlist_id]/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const load = async ({ params }) => {
 	const { playlist_id } = params;

--- a/src/routes/(site)/admin/videos/import/+page.server.ts
+++ b/src/routes/(site)/admin/videos/import/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import { get_remote_playlists, import_playlist } from '$/server/video/youtube_api';
 import { fail } from '@sveltejs/kit';
 

--- a/src/routes/(site)/guest/[name_slug]/+page.server.ts
+++ b/src/routes/(site)/guest/[name_slug]/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import { get_show_card_query } from '$/server/shows/shows_queries';
 
 export const load = async function ({ params }) {

--- a/src/routes/(site)/guests/+page.server.ts
+++ b/src/routes/(site)/guests/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const load = async function () {
 	const guests = await prisma_client.guest.findMany({

--- a/src/routes/(site)/show/[show_number]/[slug]/+layout.server.ts
+++ b/src/routes/(site)/show/[show_number]/[slug]/+layout.server.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { processor } from '$/utilities/markdown.js';
 import { cache } from '$/server/cache/cache';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const load = async function ({ params, locals, url }) {
 	const show_number = parseInt(params.show_number);

--- a/src/routes/(site)/show/[show_number]/[slug]/transcript/+page.server.ts
+++ b/src/routes/(site)/show/[show_number]/[slug]/transcript/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import { transcript_with_utterances } from '$server/ai/queries';
 import { get_show_cache_s } from '$utilities/get_show_cache_ms';
 import type { PageServerLoad } from './$types';

--- a/src/routes/(site)/sickpicks/+page.server.ts
+++ b/src/routes/(site)/sickpicks/+page.server.ts
@@ -1,6 +1,6 @@
 import type { PageServerLoad } from './$types';
 import { processor } from '$/utilities/markdown';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 function cleanUpLines(string: string) {
 	return string

--- a/src/routes/(site)/videos/+page.server.ts
+++ b/src/routes/(site)/videos/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const load = async function () {
 	const playlists = await prisma_client.playlist.findMany({

--- a/src/routes/(site)/videos/[p_slug]/+page.server.ts
+++ b/src/routes/(site)/videos/[p_slug]/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const load = async function ({ params }) {
 	const { p_slug } = params;

--- a/src/routes/(site)/videos/[p_slug]/[v_slug]/+page.server.ts
+++ b/src/routes/(site)/videos/[p_slug]/[v_slug]/+page.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import { get_show_card_query } from '$/server/shows/shows_queries';
 import { get_first_paragraph } from '$/utilities/get_first_paragraph';
 import { processor } from '$/utilities/markdown.js';

--- a/src/routes/api/oauth/github/+server.ts
+++ b/src/routes/api/oauth/github/+server.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import { GITHUB_AUTH_URL } from '$const';
 import { PUBLIC_GITHUB_ID } from '$env/static/public';
 import type { RequestHandler } from '@sveltejs/kit';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const GET: RequestHandler = async function ({ locals, cookies }) {
 	const access_token = cookies.get('access_token');

--- a/src/routes/api/seed.json/content.server.ts
+++ b/src/routes/api/seed.json/content.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export async function content() {
 	// Last 20 Shows

--- a/src/routes/api/shows/+server.ts
+++ b/src/routes/api/shows/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import { format } from 'date-fns';
 import { shows_api_query } from './query.js';
-import { prisma_client } from '$/hooks.server.js';
+import { prisma_client } from '$/server/prisma-client';
 
 export async function GET() {
 	const data = await prisma_client.show.findMany(shows_api_query());

--- a/src/routes/api/shows/[number=show_number]/+server.ts
+++ b/src/routes/api/shows/[number=show_number]/+server.ts
@@ -1,7 +1,7 @@
 import { error, json } from '@sveltejs/kit';
 import { format } from 'date-fns';
 import { shows_api_query } from '../query.js';
-import { prisma_client } from '$/hooks.server.js';
+import { prisma_client } from '$/server/prisma-client';
 
 const query = shows_api_query();
 

--- a/src/routes/api/shows/latest/+server.ts
+++ b/src/routes/api/shows/latest/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import { format } from 'date-fns';
 import { shows_api_query } from '../query.js';
-import { prisma_client } from '$/hooks.server.js';
+import { prisma_client } from '$/server/prisma-client';
 
 export async function GET() {
 	const data = await prisma_client.show.findFirst(shows_api_query());

--- a/src/routes/content.json/content.server.ts
+++ b/src/routes/content.json/content.server.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '../../hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import type { Show } from '@prisma/client';
 
 interface Block {

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { PUBLIC_URL } from '$env/static/public';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 const site = `https://${PUBLIC_URL}`;
 

--- a/src/routes/webhooks/ai/+server.ts
+++ b/src/routes/webhooks/ai/+server.ts
@@ -4,7 +4,7 @@ import { transcript_without_ai_notes_query } from '$server/ai/queries';
 import { error, json } from '@sveltejs/kit';
 import { has_auth } from '../transcripts/has_auth';
 import type { RequestEvent } from './$types';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const config = {
 	maxDuration: 300 // vercel timeout

--- a/src/routes/webhooks/transcripts/+server.ts
+++ b/src/routes/webhooks/transcripts/+server.ts
@@ -2,7 +2,7 @@ import { error, json } from '@sveltejs/kit';
 import type { RequestEvent } from './$types';
 import { get_transcript } from '$server/transcripts/deepgram';
 import { has_auth } from './has_auth';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export const config = {
 	maxDuration: 300 // vercel timeout

--- a/src/server/ai/db.ts
+++ b/src/server/ai/db.ts
@@ -1,5 +1,5 @@
 import { generate_ai_notes } from './openai';
-import { prisma_client } from '../../hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 type Show = { number: number };
 type Result = Awaited<ReturnType<typeof generate_ai_notes>>;

--- a/src/server/ai/requestHandlers.ts
+++ b/src/server/ai/requestHandlers.ts
@@ -2,7 +2,7 @@ import { error, type RequestEvent } from '@sveltejs/kit';
 import { transcript_with_utterances } from './queries';
 import { generate_ai_notes } from './openai';
 import { save_ai_notes_to_db } from './db';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export async function aiNoteRequestHandler({ request }: RequestEvent) {
 	const data = await request.formData();

--- a/src/server/auth/sessions.ts
+++ b/src/server/auth/sessions.ts
@@ -1,5 +1,5 @@
 import type { Session, User } from '@prisma/client';
-import { prisma_client } from '../../hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export async function find_session(
 	access_token: string,

--- a/src/server/auth/users.ts
+++ b/src/server/auth/users.ts
@@ -1,6 +1,6 @@
 import type { GithubUser } from '$const';
 import { add_user_to_role } from '../roles';
-import { prisma_client } from '../../hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import type { User } from '@prisma/client';
 
 export interface UserWithRoles extends User {

--- a/src/server/prisma-client.ts
+++ b/src/server/prisma-client.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prisma_client = new PrismaClient();

--- a/src/server/roles.ts
+++ b/src/server/roles.ts
@@ -1,4 +1,4 @@
-import { prisma_client } from '../hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 
 export async function add_user_to_role(userId: string, roleName: string) {
 	// Find the role by its name

--- a/src/server/shows.ts
+++ b/src/server/shows.ts
@@ -5,7 +5,7 @@ import { left_pad } from '$utilities/left_pad';
 import { error } from '@sveltejs/kit';
 import matter from 'gray-matter';
 import slug from 'speakingurl';
-import { prisma_client as prisma, redis } from '../hooks.server';
+import { prisma_client as prisma } from '$/server/prisma-client';
 import { cache } from './cache/cache';
 
 interface FrontMatterGuest {

--- a/src/server/shows/shows.ts
+++ b/src/server/shows/shows.ts
@@ -1,5 +1,6 @@
 import { get_show_detail_query, get_last_10_shows_query, get_list_shows } from './shows_queries';
 import { prisma_client } from '$/server/prisma-client';
+import { redis } from '$/hooks.server';
 import { delete_keys_by_prefix, super_cache_mang } from '../cache/cache_mang';
 
 export async function show(show_number: number) {

--- a/src/server/shows/shows.ts
+++ b/src/server/shows/shows.ts
@@ -1,5 +1,5 @@
 import { get_show_detail_query, get_last_10_shows_query, get_list_shows } from './shows_queries';
-import { prisma_client, redis } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import { delete_keys_by_prefix, super_cache_mang } from '../cache/cache_mang';
 
 export async function show(show_number: number) {

--- a/src/server/transcripts/deepgram.ts
+++ b/src/server/transcripts/deepgram.ts
@@ -3,7 +3,7 @@
 // @ts-nocheck
 import DeepgramPkg from '@deepgram/sdk';
 const { Deepgram } = DeepgramPkg;
-import { prisma_client as prisma } from '../../hooks.server';
+import { prisma_client as prisma } from '$/server/prisma-client';
 import { error } from '@sveltejs/kit';
 import { keywords } from './fixes';
 import { addFlaggerAudio } from './flagger';

--- a/src/server/transcripts/transcripts.ts
+++ b/src/server/transcripts/transcripts.ts
@@ -3,7 +3,7 @@ import type { Show } from '@prisma/client';
 import { error } from '@sveltejs/kit';
 import fs, { readFile } from 'fs/promises';
 import path from 'path';
-import { prisma_client as prisma } from '../../hooks.server';
+import { prisma_client as prisma } from '$/server/prisma-client';
 import { detectSpeakerNames, getSlimUtterances } from './utils';
 import pMap from 'p-map';
 const transcripts_path = path.join(process.cwd(), 'src/assets/transcripts-flagged');

--- a/src/server/video/youtube_api.ts
+++ b/src/server/video/youtube_api.ts
@@ -1,5 +1,5 @@
 import { YOUTUBE_CHANNEL_ID } from '$/const';
-import { prisma_client } from '$/hooks.server';
+import { prisma_client } from '$/server/prisma-client';
 import { YOUTUBE_API_KEY } from '$env/static/private';
 import slug from 'speakingurl';
 


### PR DESCRIPTION
* Moves prisma client to its own module and updates the import across the code base.
* Updated a few imports from ../hooks to $/hooks