### PR TITLE
Updated Naming Convention for Downloaded Podcast Files

### DIFF
--- a/src/routes/(site)/show/[show_number]/[slug]/+layout.svelte
+++ b/src/routes/(site)/show/[show_number]/[slug]/+layout.svelte
@@ -15,6 +15,7 @@
 
 	export let data;
 	$: ({ show, time_start } = data);
+	$: downloadName = `Show #${show.number} - ${show.title}`;
 
 	async function handleClick(e: Event) {
 		const { target } = e;
@@ -102,7 +103,13 @@
 		</div>
 		<div>
 			<SaveOffline {show} />
-			<a class="icon" title="Download Episode" aria-label="Download" download href={show.url}>
+			<a
+				class="icon"
+				title="Download Episode"
+				aria-label="Download"
+				download={downloadName}
+				href={show.url}
+			>
 				<Icon name="download" />
 			</a>
 			<a

--- a/src/routes/(site)/show/[show_number]/[slug]/+layout.svelte
+++ b/src/routes/(site)/show/[show_number]/[slug]/+layout.svelte
@@ -15,7 +15,7 @@
 
 	export let data;
 	$: ({ show, time_start } = data);
-	$: downloadName = `Show #${show.number} - ${show.title}`;
+	$: downloadName = `Syntax #${show.number} - ${show.title}`;
 
 	async function handleClick(e: Event) {
 		const { target } = e;


### PR DESCRIPTION
This pull request updates the naming convention for downloaded podcast files to be more descriptive. Previously, files were named like `Syntax_-_812.mp3`, which did not provide information about the episode content. The new format matches the one used in the "Now Playing" widget on the website, making it easier for users to identify each episode.