### PR TITLE
Use Prisma enum for Zod validation and Admin filters

### DIFF
--- a/src/lib/forms/UserSubmissionAction.ts
+++ b/src/lib/forms/UserSubmissionAction.ts
@@ -5,11 +5,9 @@ import { env } from '$env/dynamic/private';
 import { user_submission_schema } from '$/lib/forms/userSubmissionSchema';
 import { z } from 'zod';
 
-export const UserSubmissionAction: Action = async function ({ request, locals }) {
-	const form = await request.formData();
+export const user_submission_action: Action = async function ({ locals }) {
 	// Validate Turnsile Token
-
-	let { success, error } = await validateToken(
+	let { error } = await validateToken(
 		locals.form_data['cf-turnstile-response'],
 		env.TURNSTILE_SECRET
 	);
@@ -44,7 +42,7 @@ export const UserSubmissionAction: Action = async function ({ request, locals })
 		.create({
 			data: parsed.data
 		})
-		.then((result) => {
+		.then(() => {
 			return {
 				status: 200,
 				message: 'Form Submitted Successfully! Thank you.'

--- a/src/lib/forms/UserSubmissionForm.svelte
+++ b/src/lib/forms/UserSubmissionForm.svelte
@@ -4,7 +4,7 @@
 	import { Turnstile } from 'svelte-turnstile';
 	import { env } from '$env/dynamic/public';
 	import InlineError from './InlineError.svelte';
-	import type { UserSubmissionType } from '@prisma/client';
+	import { UserSubmissionType } from '@prisma/client';
 	export let form;
 	let reset: () => void | undefined;
 	export let selected_submission_type: UserSubmissionType = 'SPOOKY';

--- a/src/lib/forms/userSubmissionSchema.ts
+++ b/src/lib/forms/userSubmissionSchema.ts
@@ -1,7 +1,8 @@
+import { UserSubmissionType } from '@prisma/client';
 import { z } from 'zod';
 
 export const user_submission_schema = z.object({
-	submission_type: z.enum(['POTLUCK', 'SPOOKY', 'GUEST', 'FEEDBACK', 'OTHER']), // These values should come from the Prisma enum but they arent importing so meh
+	submission_type: z.nativeEnum(UserSubmissionType),
 	body: z.string().min(25).max(15000),
 	name: z.optional(z.string().max(100)),
 	email: z.optional(z.union([z.string().email().max(100), z.literal('')]))

--- a/src/routes/(site)/admin/submissions/+page.server.ts
+++ b/src/routes/(site)/admin/submissions/+page.server.ts
@@ -5,7 +5,6 @@ import type { Actions, PageServerLoad } from './$types';
 import type { equal } from 'assert';
 
 export const load: PageServerLoad = async ({ url }) => {
-	console.log('params', url.searchParams.entries());
 	const submission_type = url.searchParams.get('submission_type');
 	const status = url.searchParams.get('status');
 	const per_page = parseInt(url.searchParams.get('perPage') || '') || 100;
@@ -31,7 +30,7 @@ export const load: PageServerLoad = async ({ url }) => {
 		};
 	}
 
-	const submissionCount = await prisma_client.userSubmission.count({
+	const submission_count = await prisma_client.userSubmission.count({
 		...submissions_query,
 		take: undefined
 	});
@@ -39,7 +38,7 @@ export const load: PageServerLoad = async ({ url }) => {
 	const submissions = await prisma_client.userSubmission.findMany(submissions_query);
 	return {
 		submissions,
-		submissionCount
+		submission_count
 	};
 };
 

--- a/src/routes/(site)/admin/submissions/+page.svelte
+++ b/src/routes/(site)/admin/submissions/+page.svelte
@@ -4,6 +4,7 @@
 	import { queryParameters } from 'sveltekit-search-params';
 	import SelectMenu from '$/lib/SelectMenu.svelte';
 	import FormWithLoader from '$/lib/FormWithLoader.svelte';
+	import { UserSubmissionStatus, UserSubmissionType } from '@prisma/client';
 	const store = queryParameters<{
 		submission_type?: string;
 		status?: string;
@@ -13,10 +14,10 @@
 	}>();
 
 	export let data: PageData;
-	$: ({ submissions, submissionCount } = data);
+	$: ({ submissions, submission_count } = data);
 </script>
 
-<h1 class="h4">Submissions ({submissionCount})</h1>
+<h1 class="h4">Submissions ({submission_count})</h1>
 
 <div class="submission-filter">
 	<nav>
@@ -30,11 +31,7 @@
 			value={$store.submission_type || ''}
 			options={[
 				{ value: '', label: 'All' },
-				{ value: 'POTLUCK', label: 'POTLUCK' },
-				{ value: 'SPOOKY', label: 'SPOOKY' },
-				{ value: 'GUEST', label: 'GUEST' },
-				{ value: 'FEEDBACK', label: 'FEEDBACK' },
-				{ value: 'OTHER', label: 'OTHER' }
+				...Object.keys(UserSubmissionType).map((key) => ({ value: key, label: key }))
 			]}
 		/>
 		<SelectMenu
@@ -47,10 +44,7 @@
 			value={$store.status || ''}
 			options={[
 				{ value: '', label: 'All' },
-				{ value: 'PENDING', label: 'PENDING' },
-				{ value: 'APPROVED', label: 'APPROVED' },
-				{ value: 'COMPLETED', label: 'COMPLETED' },
-				{ value: 'REJECTED', label: 'REJECTED' }
+				...Object.keys(UserSubmissionStatus).map((key) => ({ value: key, label: key }))
 			]}
 		/>
 		<SelectMenu

--- a/src/routes/(site)/oss/+page.server.ts
+++ b/src/routes/(site)/oss/+page.server.ts
@@ -1,6 +1,6 @@
 import { type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-import { UserSubmissionAction } from '$/lib/forms/UserSubmissionAction';
+import { user_submission_action } from '$/lib/forms/UserSubmissionAction';
 export const load: PageServerLoad = async function () {
 	return {
 		meta: {
@@ -11,5 +11,5 @@ export const load: PageServerLoad = async function () {
 };
 
 export const actions: Actions = {
-	default: UserSubmissionAction
+	default: user_submission_action
 };

--- a/src/routes/(site)/potluck/+page.server.ts
+++ b/src/routes/(site)/potluck/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-import { UserSubmissionAction } from '$/lib/forms/UserSubmissionAction';
+import { user_submission_action } from '$/lib/forms/UserSubmissionAction';
 export const load: PageServerLoad = async function () {
 	return {
 		meta: {
@@ -10,5 +10,5 @@ export const load: PageServerLoad = async function () {
 };
 
 export const actions: Actions = {
-	default: UserSubmissionAction
+	default: user_submission_action
 };

--- a/src/routes/(site)/spooky/+page.server.ts
+++ b/src/routes/(site)/spooky/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-import { UserSubmissionAction } from '$/lib/forms/UserSubmissionAction';
+import { user_submission_action } from '$/lib/forms/UserSubmissionAction';
 export const load: PageServerLoad = async function () {
 	return {
 		meta: {
@@ -10,5 +10,5 @@ export const load: PageServerLoad = async function () {
 };
 
 export const actions: Actions = {
-	default: UserSubmissionAction
+	default: user_submission_action
 };


### PR DESCRIPTION
This PR uses the Prisma DB enum both for the Zod validation and the admin filter dropdowns. Should make adding new types of submissions easy. 

Also migrated all files I touched to snake_case