### PR TITLE
Converts svelte state to snapshot before passing to postMessage API

### DIFF
--- a/src/lib/search/SearchBox.svelte
+++ b/src/lib/search/SearchBox.svelte
@@ -81,7 +81,6 @@
 
 	run(() => {
 		if (ready) {
-			console.log('recents', $search_recent);
 			worker.postMessage({ type: 'recents', payload: $state.snapshot($search_recent) });
 		}
 	});

--- a/src/lib/search/SearchBox.svelte
+++ b/src/lib/search/SearchBox.svelte
@@ -81,7 +81,8 @@
 
 	run(() => {
 		if (ready) {
-			worker.postMessage({ type: 'recents', payload: $search_recent });
+			console.log('recents', $search_recent);
+			worker.postMessage({ type: 'recents', payload: $state.snapshot($search_recent) });
 		}
 	});
 


### PR DESCRIPTION
Svelte state is a proxy, and since we need to pass that to worker.postMessagae to log a recent search, it was breaking. 

Thanks to @hudochenkov and @s-petey  for the report + fix. 

https://github.com/syntaxfm/website/issues/1931