### PR TITLE
Make ⌘ and K characters in search bar the same height

### DIFF
--- a/src/lib/search/Search.svelte
+++ b/src/lib/search/Search.svelte
@@ -36,4 +36,9 @@
 			display: none;
 		}
 	}
+
+	.shortcut kbd {
+		font-family: system-ui, sans-serif;
+		font-size: var(--font-size-xs);
+	}
 </style>


### PR DESCRIPTION
Fix a style issue where the ⌘ and K characters in the search bar were mismatched heights.

Before this fix:
<img width="197" alt="Screenshot 2025-05-06 at 8 34 09 PM" src="https://github.com/user-attachments/assets/8952d5a0-0564-473a-ab0c-d08e26afd0c3" />

After this fix:
<img width="204" alt="Screenshot 2025-05-06 at 8 34 21 PM" src="https://github.com/user-attachments/assets/aef450fe-7305-4adf-ac47-92c6f13569f8" />
