### PR TITLE
Fix home page frequency text

### DIFF
--- a/src/lib/schedule.svelte
+++ b/src/lib/schedule.svelte
@@ -1,5 +1,5 @@
 <section>
-	<p class="lines thrice">Served Fresh Thrice Weekly</p>
+	<p class="lines thrice">Served Fresh Twice Weekly</p>
 	<div>
 		<p class="tag length">15m</p>
 		<p class="tag day">Monday</p>


### PR DESCRIPTION
The `src/lib/schedule.svelte` file was modified to correct the podcast frequency displayed on the homepage.

*   The text "Served Fresh Thrice Weekly" was updated to "Served Fresh Twice Weekly" within the `<p>` tag on line 2.
*   This change ensures visitors see the accurate publication schedule, addressing the reported issue where the homepage incorrectly stated "Thrice weekly."
*   The `schedule.svelte` component is integrated into the `PodcastHero` component, which is displayed on the homepage, ensuring the correct information is presented to users.