### PR TITLE
Fix missing OG images by correcting file extension mismatch

### DIFF
--- a/src/lib/meta/Meta.svelte
+++ b/src/lib/meta/Meta.svelte
@@ -9,7 +9,7 @@
 		description: `Full Stack Web Developers Wes Bos and Scott Tolinski dive deep into web development, CSS, JavaScript, Frameworks, Typescript, Servers and more. Listen in 3 times a week!`,
 		image: `${$page.url.protocol}//${$page.url.host}/og/${encodeURIComponent(
 			$page.data.meta?.title || title
-		)}.jpg`,
+		)}.jpeg`,
 		title,
 		// any page customizations
 		...$page.data.meta


### PR DESCRIPTION
Fixes #1996 - images were missing due to extension mismatch between  meta tags (.jpg) and server response (.jpeg)

## Problem
All images were missing from the site due to a file extension mismatch.

## Root Cause
- Meta tags were requesting OG images with `.jpg` extension
- Server was generating images with `.jpeg` extension (from puppeteer screenshot type)
- This caused 404s for all OG images

## Solution
Changed meta image URL generation from `.jpg` to `.jpeg` to match the server's screenshot output format.

## Changes
- Updated `image` property in meta object to use `.jpeg` extension
- Now matches the `type: 'jpeg'` format from puppeteer screenshot

Fixes #1996